### PR TITLE
Propagate context deadline to request timeout header

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -18,7 +18,7 @@ import (
 const version = "v0.0.6"
 
 const (
-	// Nexus specific headers
+	// Nexus specific headers.
 	headerOperationState = "Nexus-Operation-State"
 	headerOperationID    = "Nexus-Operation-Id"
 	headerRequestID      = "Nexus-Request-Id"

--- a/nexus/api.go
+++ b/nexus/api.go
@@ -4,21 +4,27 @@
 package nexus
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"mime"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Package version.
 const version = "v0.0.6"
 
 const (
+	// Nexus specific headers
 	headerOperationState = "Nexus-Operation-State"
 	headerOperationID    = "Nexus-Operation-Id"
 	headerRequestID      = "Nexus-Request-Id"
+
+	// General HTTP headers.
+	headerRequestTimeout = "Request-Timeout"
 )
 
 const contentTypeJSON = "application/json"
@@ -160,5 +166,14 @@ func addNexusHeaderToHTTPHeader(nexusHeader Header, httpHeader http.Header) http
 	for k, v := range nexusHeader {
 		httpHeader.Set(k, v)
 	}
+	return httpHeader
+}
+
+func addContextTimeoutToHTTPHeader(ctx context.Context, httpHeader http.Header) http.Header {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return httpHeader
+	}
+	httpHeader.Set(headerRequestTimeout, time.Until(deadline).String())
 	return httpHeader
 }

--- a/nexus/cancel_test.go
+++ b/nexus/cancel_test.go
@@ -95,8 +95,9 @@ func TestCancel_ContextDeadlinePropagated(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCancel_RequestTimeoutHeaderPropagated(t *testing.T) {
+func TestCancel_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 	timeout := 100 * time.Millisecond
+	// relies on ctx returned here having default testTimeout set greater than expected timeout
 	ctx, client, teardown := setup(t, &echoTimeoutAsyncWithCancelHandler{expectedTimeout: timeout})
 	defer teardown()
 

--- a/nexus/cancel_test.go
+++ b/nexus/cancel_test.go
@@ -108,12 +108,11 @@ func TestCancel_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 }
 
 func TestCancel_TimeoutNotPropagated(t *testing.T) {
-	ctx, client, teardown := setup(t, &echoTimeoutAsyncWithCancelHandler{})
+	_, client, teardown := setup(t, &echoTimeoutAsyncWithCancelHandler{})
 	defer teardown()
 
-	ctx = context.Background()
 	handle, err := client.NewHandle("foo", "timeout")
 	require.NoError(t, err)
-	err = handle.Cancel(ctx, CancelOperationOptions{})
+	err = handle.Cancel(context.Background(), CancelOperationOptions{})
 	require.NoError(t, err)
 }

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -185,8 +185,6 @@ func (c *Client) StartOperation(ctx context.Context, operation string, input any
 		return nil, err
 	}
 
-	// Use provided header as a base.
-	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 	if options.RequestID == "" {
 		options.RequestID = uuid.NewString()
 	}
@@ -195,6 +193,7 @@ func (c *Client) StartOperation(ctx context.Context, operation string, input any
 	addContentHeaderToHTTPHeader(reader.Header, request.Header)
 	addCallbackHeaderToHTTPHeader(options.CallbackHeader, request.Header)
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
+	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 
 	response, err := c.options.HTTPCaller(request)
 	if err != nil {
@@ -269,8 +268,10 @@ type ExecuteOperationOptions struct {
 	RequestID string
 	// Header to attach to start and get-result requests. Optional.
 	//
+	// Header values set here will overwrite any SDK-provided values for the same key.
+	//
 	// Header keys with the "content-" prefix are reserved for [Serializer] headers and should not be set in the
-	// client API; they are not be avaliable to server [Handler] and [Operation] implementations.
+	// client API; they are not available to server [Handler] and [Operation] implementations.
 	Header Header
 	// Duration to wait for operation completion.
 	//

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -194,6 +194,7 @@ func (c *Client) StartOperation(ctx context.Context, operation string, input any
 	request.Header.Set(headerUserAgent, userAgent)
 	addContentHeaderToHTTPHeader(reader.Header, request.Header)
 	addCallbackHeaderToHTTPHeader(options.CallbackHeader, request.Header)
+	addContextTimeoutToHTTPHeader(ctx, request.Header)
 
 	response, err := c.options.HTTPCaller(request)
 	if err != nil {

--- a/nexus/get_info_test.go
+++ b/nexus/get_info_test.go
@@ -106,8 +106,9 @@ func TestGetInfo_ContextDeadlinePropagated(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetInfo_RequestTimeoutHeaderPropagated(t *testing.T) {
+func TestGetInfo_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 	timeout := 100 * time.Millisecond
+	// relies on ctx returned here having default testTimeout set greater than expected timeout
 	ctx, client, teardown := setup(t, &asyncWithInfoTimeoutHandler{expectedTimeout: timeout})
 	defer teardown()
 

--- a/nexus/get_info_test.go
+++ b/nexus/get_info_test.go
@@ -119,12 +119,11 @@ func TestGetInfo_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 }
 
 func TestGetInfo_TimeoutNotPropagated(t *testing.T) {
-	ctx, client, teardown := setup(t, &asyncWithInfoTimeoutHandler{})
+	_, client, teardown := setup(t, &asyncWithInfoTimeoutHandler{})
 	defer teardown()
 
-	ctx = context.Background()
 	handle, err := client.NewHandle("foo", "timeout")
 	require.NoError(t, err)
-	_, err = handle.GetInfo(ctx, GetOperationInfoOptions{})
+	_, err = handle.GetInfo(context.Background(), GetOperationInfoOptions{})
 	require.NoError(t, err)
 }

--- a/nexus/get_info_test.go
+++ b/nexus/get_info_test.go
@@ -3,6 +3,7 @@ package nexus
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +64,124 @@ func TestGetInfoHandleFromClientNoHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, handle.ID, info.ID)
 	require.Equal(t, OperationStateCanceled, info.State)
+}
+
+type asyncWithInfoTimeoutHandler struct {
+	UnimplementedHandler
+}
+
+func (h *asyncWithInfoTimeoutHandler) StartOperation(ctx context.Context, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
+	return &HandlerStartOperationResultAsync{
+		OperationID: "needs /URL/ escaping",
+	}, nil
+}
+
+func (h *asyncWithInfoTimeoutHandler) GetOperationInfo(ctx context.Context, operation, operationID string, options GetOperationInfoOptions) (*OperationInfo, error) {
+	time.Sleep(20 * time.Millisecond)
+
+	if ctx.Err() != nil {
+		return nil, HandlerErrorf(HandlerErrorTypeDownstreamTimeout, "handler exceeded request timeout of %s", options.Header.Get(headerRequestTimeout))
+	}
+
+	return &OperationInfo{
+		ID:    operationID,
+		State: OperationStateCanceled,
+	}, nil
+}
+
+func TestGetInfoHandlerTimeout(t *testing.T) {
+	ctx, client, teardown := setup(t, &asyncWithInfoTimeoutHandler{})
+	defer teardown()
+
+	type testcase struct {
+		name         string
+		timeout      time.Duration
+		setOnHeader  bool
+		setOnContext bool
+		validator    func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error)
+	}
+	cases := []testcase{
+		{
+			name:         "time_out: set on context",
+			timeout:      1 * time.Millisecond,
+			setOnHeader:  false,
+			setOnContext: true,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.ErrorContains(t, err, "context deadline exceeded")
+			},
+		},
+		{
+			name:         "time_out: set on header",
+			timeout:      1 * time.Millisecond,
+			setOnHeader:  true,
+			setOnContext: false,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.ErrorContains(t, err, "handler exceeded request timeout of 1ms")
+			},
+		},
+		{
+			name:         "time_out: set on context and header",
+			timeout:      1 * time.Millisecond,
+			setOnHeader:  true,
+			setOnContext: true,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.ErrorContains(t, err, "context deadline exceeded")
+			},
+		},
+		{
+			name:         "success: set on context",
+			timeout:      5 * time.Second,
+			setOnHeader:  false,
+			setOnContext: true,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.NoError(t, err)
+				require.Equal(t, handle.ID, info.ID)
+				require.Equal(t, OperationStateCanceled, info.State)
+			},
+		},
+		{
+			name:         "success: set on header",
+			timeout:      5 * time.Second,
+			setOnHeader:  true,
+			setOnContext: false,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.NoError(t, err)
+				require.Equal(t, handle.ID, info.ID)
+				require.Equal(t, OperationStateCanceled, info.State)
+			},
+		},
+		{
+			name:         "success: set on context and header",
+			timeout:      5 * time.Second,
+			setOnHeader:  true,
+			setOnContext: false,
+			validator: func(t *testing.T, handle *OperationHandle[*LazyValue], info *OperationInfo, err error) {
+				require.NoError(t, err)
+				require.Equal(t, handle.ID, info.ID)
+				require.Equal(t, OperationStateCanceled, info.State)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			handle, err := client.NewHandle("escape/me", "needs /URL/ escaping")
+			require.NoError(t, err)
+
+			requestCtx := ctx
+			if c.setOnContext {
+				var cancel context.CancelFunc
+				requestCtx, cancel = context.WithTimeout(ctx, c.timeout)
+				defer cancel()
+			}
+			opts := GetOperationInfoOptions{}
+			if c.setOnHeader {
+				opts.Header = Header{headerRequestTimeout: c.timeout.String()}
+			}
+
+			info, err := handle.GetInfo(requestCtx, opts)
+			c.validator(t, handle, info, err)
+		})
+	}
 }

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -28,6 +28,7 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 		return nil, err
 	}
 	addNexusHeaderToHTTPHeader(options.Header, request.Header)
+	addContextTimeoutToHTTPHeader(ctx, request.Header)
 
 	request.Header.Set(headerUserAgent, userAgent)
 	response, err := h.client.options.HTTPCaller(request)
@@ -72,6 +73,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 		return result, err
 	}
 	addNexusHeaderToHTTPHeader(options.Header, request.Header)
+	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
 
 	startTime := time.Now()
@@ -119,6 +121,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 }
 
 func (h *OperationHandle[T]) sendGetOperationRequest(ctx context.Context, request *http.Request) (*http.Response, error) {
+	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {
 		return nil, err
@@ -167,6 +170,7 @@ func (h *OperationHandle[T]) Cancel(ctx context.Context, options CancelOperation
 		return err
 	}
 	addNexusHeaderToHTTPHeader(options.Header, request.Header)
+	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -27,8 +27,8 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 	if err != nil {
 		return nil, err
 	}
-	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
+	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 
 	request.Header.Set(headerUserAgent, userAgent)
 	response, err := h.client.options.HTTPCaller(request)
@@ -72,9 +72,9 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 	if err != nil {
 		return result, err
 	}
-	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
+	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 
 	startTime := time.Now()
 	wait := options.Wait
@@ -121,7 +121,6 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 }
 
 func (h *OperationHandle[T]) sendGetOperationRequest(ctx context.Context, request *http.Request) (*http.Response, error) {
-	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {
 		return nil, err
@@ -169,9 +168,9 @@ func (h *OperationHandle[T]) Cancel(ctx context.Context, options CancelOperation
 	if err != nil {
 		return err
 	}
-	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
+	addNexusHeaderToHTTPHeader(options.Header, request.Header)
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {
 		return err

--- a/nexus/options.go
+++ b/nexus/options.go
@@ -10,8 +10,10 @@ type StartOperationOptions struct {
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
 	//
+	// Header values set here will overwrite any SDK-provided values for the same key.
+	//
 	// Header keys with the "content-" prefix are reserved for [Serializer] headers and should not be set in the
-	// client API; they are not be avaliable to server [Handler] and [Operation] implementations.
+	// client API; they are not available to server [Handler] and [Operation] implementations.
 	Header Header
 	// Callbacks are used to deliver completion of async operations.
 	// This value may optionally be set by the client and should be called by a handler upon completion if the started operation is async.
@@ -31,6 +33,8 @@ type GetOperationResultOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
+	//
+	// Header values set here will overwrite any SDK-provided values for the same key.
 	Header Header
 	// If non-zero, reflects the duration the caller has indicated that it wants to wait for operation completion,
 	// turning the request into a long poll.
@@ -42,6 +46,8 @@ type GetOperationInfoOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
+	//
+	// Header values set here will overwrite any SDK-provided values for the same key.
 	Header Header
 }
 
@@ -50,5 +56,7 @@ type CancelOperationOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
+	//
+	// Header values set here will overwrite any SDK-provided values for the same key.
 	Header Header
 }

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -349,7 +349,11 @@ func (h *httpHandler) getOperationResult(writer http.ResponseWriter, request *ht
 			return
 		}
 		options.Wait = waitDuration
-		ctxTimeout = min(ctxTimeout, waitDuration)
+		if ctxTimeout <= 0 {
+			ctxTimeout = min(ctxTimeout, waitDuration)
+		} else {
+			ctxTimeout = waitDuration
+		}
 	}
 	if ctxTimeout > 0 {
 		var cancel context.CancelFunc

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -349,7 +349,7 @@ func (h *httpHandler) getOperationResult(writer http.ResponseWriter, request *ht
 			return
 		}
 		options.Wait = waitDuration
-		if ctxTimeout <= 0 {
+		if ctxTimeout > 0 {
 			ctxTimeout = min(ctxTimeout, waitDuration)
 		} else {
 			ctxTimeout = waitDuration

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -305,11 +305,10 @@ func requireTimeoutPropagated(t *testing.T, result *ClientStartOperationResult[*
 }
 
 func TestStart_TimeoutNotPropagated(t *testing.T) {
-	ctx, client, teardown := setup(t, &timeoutEchoHandler{})
+	_, client, teardown := setup(t, &timeoutEchoHandler{})
 	defer teardown()
 
-	ctx = context.Background()
-	result, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{})
+	result, err := client.StartOperation(context.Background(), "foo", nil, StartOperationOptions{})
 
 	require.NoError(t, err)
 	response := result.Successful

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -280,7 +280,8 @@ func TestStart_ContextDeadlinePropagated(t *testing.T) {
 	requireTimeoutPropagated(t, result, initialTimeout)
 }
 
-func TestStart_RequestTimeoutHeaderPropagated(t *testing.T) {
+func TestStart_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
+	// relies on ctx returned here having default testTimeout set greater than expected timeout
 	ctx, client, teardown := setup(t, &timeoutEchoHandler{})
 	defer teardown()
 


### PR DESCRIPTION
Added handling for propagating context deadlines
* For client (outgoing) requests: the context deadline is set on the HTTP request header `Request-Timeout`
* For for server (incoming) requests: if set, the `Request-Timeout` HTTP request header is applied to the context returned by the HTTP request
