### PR TITLE
Fix nil map assignment when content is given as input to StartOperation

### DIFF
--- a/nexus/client.go
+++ b/nexus/client.go
@@ -165,6 +165,9 @@ func (c *Client) StartOperation(ctx context.Context, operation string, input any
 			}
 		}
 		header := maps.Clone(content.Header)
+		if header == nil {
+			header = make(Header, 1)
+		}
 		header["length"] = strconv.Itoa(len(content.Data))
 
 		reader = &Reader{

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -318,3 +318,17 @@ func TestStart_TimeoutNotPropagated(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("not set"), responseBody)
 }
+
+func TestStart_NilContentHeaderDoesNotPanic(t *testing.T) {
+	_, client, teardown := setup(t, &requestIDEchoHandler{})
+	defer teardown()
+
+	result, err := client.StartOperation(context.Background(), "op", &Content{Data: []byte("abc")}, StartOperationOptions{})
+
+	require.NoError(t, err)
+	response := result.Successful
+	require.NotNil(t, response)
+	var responseBody []byte
+	err = response.Consume(&responseBody)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Stumbled upon this when integrating with Temporal.