### PR TITLE
Error improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ if err != nil {
 	if errors.As(err, &unsuccessfulOperationError) { // operation failed or canceled
 		fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Failure.Message)
 	}
-	// handle arbitrary errors here
+	var handlerError *nexus.HandlerError
+	if errors.As(err, &handlerError) {
+		fmt.Printf("Handler returned an error, type: %s, failure message: %s\n", handlerError.Type, handlerError.Failure.Message)
+	}
+	// most other errors should be returned as *nexus.UnexpectedResponseError
 }
 if result.Successful != nil { // operation successful
 	output := result.Successful // output is of type MyOutput

--- a/nexus/api.go
+++ b/nexus/api.go
@@ -41,8 +41,8 @@ const (
 const (
 	statusOperationRunning = http.StatusPreconditionFailed
 	// HTTP status code for failed operation responses.
-	statusOperationFailed   = http.StatusFailedDependency
-	StatusDownstreamTimeout = 520
+	statusOperationFailed = http.StatusFailedDependency
+	StatusUpstreamTimeout = 520
 )
 
 // A Failure represents failed handler invocations as well as `failed` or `canceled` operation results.

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -275,7 +275,7 @@ func (c *Client) StartOperation(
 			Failure: failure,
 		}
 	default:
-		return nil, tryHandlerErrorFromResponse(response, body)
+		return nil, bestEffortHandlerErrorFromResponse(response, body)
 	}
 }
 
@@ -408,7 +408,7 @@ func failureFromResponseOrDefault(response *http.Response, body []byte, defaultM
 	return failure
 }
 
-func tryHandlerErrorFromResponse(response *http.Response, body []byte) error {
+func bestEffortHandlerErrorFromResponse(response *http.Response, body []byte) error {
 	switch response.StatusCode {
 	case http.StatusBadRequest:
 		failure := failureFromResponseOrDefault(response, body, "bad request")

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -275,7 +275,7 @@ func (c *Client) StartOperation(
 			Failure: failure,
 		}
 	default:
-		return nil, newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
+		return nil, tryHandlerErrorFromResponse(response, body)
 	}
 }
 
@@ -398,6 +398,48 @@ func failureFromResponse(response *http.Response, body []byte) (Failure, error) 
 	var failure Failure
 	err := json.Unmarshal(body, &failure)
 	return failure, err
+}
+
+func failureFromResponseOrDefault(response *http.Response, body []byte, defaultMessage string) Failure {
+	failure, err := failureFromResponse(response, body)
+	if err != nil {
+		failure.Message = defaultMessage
+	}
+	return failure
+}
+
+func tryHandlerErrorFromResponse(response *http.Response, body []byte) error {
+	switch response.StatusCode {
+	case http.StatusBadRequest:
+		failure := failureFromResponseOrDefault(response, body, "bad request")
+		return &HandlerError{Type: HandlerErrorTypeBadRequest, Failure: &failure}
+	case http.StatusUnauthorized:
+		failure := failureFromResponseOrDefault(response, body, "unauthenticated")
+		return &HandlerError{Type: HandlerErrorTypeUnauthenticated, Failure: &failure}
+	case http.StatusForbidden:
+		failure := failureFromResponseOrDefault(response, body, "unauthorized")
+		return &HandlerError{Type: HandlerErrorTypeUnauthorized, Failure: &failure}
+	case http.StatusNotFound:
+		failure := failureFromResponseOrDefault(response, body, "not found")
+		return &HandlerError{Type: HandlerErrorTypeNotFound, Failure: &failure}
+	case http.StatusTooManyRequests:
+		failure := failureFromResponseOrDefault(response, body, "resource exhausted")
+		return &HandlerError{Type: HandlerErrorTypeResourceExhausted, Failure: &failure}
+	case http.StatusInternalServerError:
+		failure := failureFromResponseOrDefault(response, body, "internal error")
+		return &HandlerError{Type: HandlerErrorTypeInternal, Failure: &failure}
+	case http.StatusNotImplemented:
+		failure := failureFromResponseOrDefault(response, body, "not implemented")
+		return &HandlerError{Type: HandlerErrorTypeNotImplemented, Failure: &failure}
+	case http.StatusServiceUnavailable:
+		failure := failureFromResponseOrDefault(response, body, "unavailable")
+		return &HandlerError{Type: HandlerErrorTypeUnavailable, Failure: &failure}
+	case StatusUpstreamTimeout:
+		failure := failureFromResponseOrDefault(response, body, "upstream timeout")
+		return &HandlerError{Type: HandlerErrorTypeUpstreamTimeout, Failure: &failure}
+	default:
+		return newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
+	}
 }
 
 func getUnsuccessfulStateFromHeader(response *http.Response, body []byte) (OperationState, error) {

--- a/nexus/client_example_test.go
+++ b/nexus/client_example_test.go
@@ -22,7 +22,11 @@ func ExampleClient_StartOperation() {
 		if errors.As(err, &unsuccessfulOperationError) { // operation failed or canceled
 			fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Failure.Message)
 		}
-		// handle error here
+		var handlerError *nexus.HandlerError
+		if errors.As(err, &handlerError) {
+			fmt.Printf("Handler returned an error, type: %s, failure message: %s\n", handlerError.Type, handlerError.Failure.Message)
+		}
+		// most other errors should be returned as *nexus.UnexpectedResponseError
 	}
 	if result.Successful != nil { // operation successful
 		response := result.Successful

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -43,7 +43,7 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
+		return nil, tryHandlerErrorFromResponse(response, body)
 	}
 
 	return operationInfoFromResponse(response, body)
@@ -155,7 +155,7 @@ func (h *OperationHandle[T]) sendGetOperationRequest(ctx context.Context, reques
 			Failure: failure,
 		}
 	default:
-		return nil, newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
+		return nil, tryHandlerErrorFromResponse(response, body)
 	}
 }
 
@@ -183,7 +183,7 @@ func (h *OperationHandle[T]) Cancel(ctx context.Context, options CancelOperation
 	}
 
 	if response.StatusCode != http.StatusAccepted {
-		return newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
+		return tryHandlerErrorFromResponse(response, body)
 	}
 	return nil
 }

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -43,7 +43,7 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, tryHandlerErrorFromResponse(response, body)
+		return nil, bestEffortHandlerErrorFromResponse(response, body)
 	}
 
 	return operationInfoFromResponse(response, body)
@@ -155,7 +155,7 @@ func (h *OperationHandle[T]) sendGetOperationRequest(ctx context.Context, reques
 			Failure: failure,
 		}
 	default:
-		return nil, tryHandlerErrorFromResponse(response, body)
+		return nil, bestEffortHandlerErrorFromResponse(response, body)
 	}
 }
 
@@ -183,7 +183,7 @@ func (h *OperationHandle[T]) Cancel(ctx context.Context, options CancelOperation
 	}
 
 	if response.StatusCode != http.StatusAccepted {
-		return tryHandlerErrorFromResponse(response, body)
+		return bestEffortHandlerErrorFromResponse(response, body)
 	}
 	return nil
 }

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -124,8 +124,8 @@ const (
 	HandlerErrorTypeNotImplemented HandlerErrorType = "NOT_IMPLEMENTED"
 	// The service is currently unavailable.
 	HandlerErrorTypeUnavailable HandlerErrorType = "UNAVAILABLE"
-	// Used by gateways to report that a request to a downstream server has timed out.
-	HandlerErrorTypeDownstreamTimeout HandlerErrorType = "DOWNSTREAM_TIMEOUT"
+	// Used by gateways to report that a request to an upstream server has timed out.
+	HandlerErrorTypeUpstreamTimeout HandlerErrorType = "UPSTREAM_TIMEOUT"
 )
 
 // HandlerError is a special error that can be returned from [Handler] methods for failing a request with a custom
@@ -242,8 +242,8 @@ func (h *baseHTTPHandler) writeFailure(writer http.ResponseWriter, err error) {
 			statusCode = http.StatusNotImplemented
 		case HandlerErrorTypeUnavailable:
 			statusCode = http.StatusServiceUnavailable
-		case HandlerErrorTypeDownstreamTimeout:
-			statusCode = StatusDownstreamTimeout
+		case HandlerErrorTypeUpstreamTimeout:
+			statusCode = StatusUpstreamTimeout
 		default:
 			h.logger.Error("unexpected handler error type", "type", handlerError.Type)
 		}


### PR DESCRIPTION
💥  Breaking changes 💥 
- Rename `HandlerErrorTypeDowntreamTimeout ` to `HandlerErrorTypeUpstreamTimeout ` and `StatusDownstreamTimeout` to `StatusUpstreamTimeout`. It was wrongly named.
- Do a best effort conversion between HTTP errors to `HandlerError`s and only return `UnexepectedResponseError` as a last resort. This should help hide HTTP transport details and give a more symmetrical experience between clients and handlers.