### PR TITLE
Add Operation InputType and OutputType helper methods

### DIFF
--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -20,6 +20,8 @@ type NoValue *struct{}
 // available.
 type OperationReference[I, O any] interface {
 	Name() string
+	// IsInputCompatible returns a boolean indicating whether the given input is assignable to the generic I type.
+	IsInputAssignable(any) bool
 	// A type inference helper for implementations of this interface.
 	inferType(I, O)
 }
@@ -34,6 +36,13 @@ func NewOperationReference[I, O any](name string) OperationReference[I, O] {
 
 func (r operationReference[I, O]) Name() string {
 	return string(r)
+}
+
+func (r operationReference[I, O]) IsInputAssignable(i any) bool {
+	var zero [0]I
+	tt := reflect.TypeOf(zero).Elem()
+	it := reflect.TypeOf(i)
+	return it.AssignableTo(tt)
 }
 
 func (operationReference[I, O]) inferType(I, O) {} //nolint:unused

--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -20,8 +20,10 @@ type NoValue *struct{}
 // available.
 type OperationReference[I, O any] interface {
 	Name() string
-	// IsInputCompatible returns a boolean indicating whether the given input is assignable to the generic I type.
-	IsInputAssignable(any) bool
+	// InputType the generic input type I for this operation.
+	InputType() reflect.Type
+	// OutputType the generic out type O for this operation.
+	OutputType() reflect.Type
 	// A type inference helper for implementations of this interface.
 	inferType(I, O)
 }
@@ -38,11 +40,14 @@ func (r operationReference[I, O]) Name() string {
 	return string(r)
 }
 
-func (r operationReference[I, O]) IsInputAssignable(i any) bool {
+func (operationReference[I, O]) InputType() reflect.Type {
 	var zero [0]I
-	tt := reflect.TypeOf(zero).Elem()
-	it := reflect.TypeOf(i)
-	return it.AssignableTo(tt)
+	return reflect.TypeOf(zero).Elem()
+}
+
+func (operationReference[I, O]) OutputType() reflect.Type {
+	var zero [0]O
+	return reflect.TypeOf(zero).Elem()
 }
 
 func (operationReference[I, O]) inferType(I, O) {} //nolint:unused

--- a/nexus/operation_test.go
+++ b/nexus/operation_test.go
@@ -3,6 +3,7 @@ package nexus
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -255,7 +256,10 @@ func TestHandlerError(t *testing.T) {
 	require.Equal(t, "unauthorized in test", handlerError.Failure.Message)
 }
 
-func TestIsInputAssignable(t *testing.T) {
-	require.True(t, numberValidatorOperation.IsInputAssignable(3))
-	require.False(t, numberValidatorOperation.IsInputAssignable("s"))
+func TestInputOutputType(t *testing.T) {
+	require.True(t, reflect.TypeOf(3).AssignableTo(numberValidatorOperation.InputType()))
+	require.False(t, reflect.TypeOf("s").AssignableTo(numberValidatorOperation.InputType()))
+
+	require.True(t, reflect.TypeOf(3).AssignableTo(numberValidatorOperation.OutputType()))
+	require.False(t, reflect.TypeOf("s").AssignableTo(numberValidatorOperation.OutputType()))
 }

--- a/nexus/operation_test.go
+++ b/nexus/operation_test.go
@@ -254,3 +254,8 @@ func TestHandlerError(t *testing.T) {
 	require.Equal(t, HandlerErrorTypeUnauthorized, handlerError.Type)
 	require.Equal(t, "unauthorized in test", handlerError.Failure.Message)
 }
+
+func TestIsInputAssignable(t *testing.T) {
+	require.True(t, numberValidatorOperation.IsInputAssignable(3))
+	require.False(t, numberValidatorOperation.IsInputAssignable("s"))
+}

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -41,11 +41,14 @@ func (*UnimplementedOperation[I, O]) inferType(I, O) {} //nolint:unused
 
 func (*UnimplementedOperation[I, O]) mustEmbedUnimplementedOperation() {}
 
-func (*UnimplementedOperation[I, O]) IsInputAssignable(i any) bool {
+func (*UnimplementedOperation[I, O]) InputType() reflect.Type {
 	var zero [0]I
-	tt := reflect.TypeOf(zero).Elem()
-	it := reflect.TypeOf(i)
-	return it.AssignableTo(tt)
+	return reflect.TypeOf(zero).Elem()
+}
+
+func (*UnimplementedOperation[I, O]) OutputType() reflect.Type {
+	var zero [0]O
+	return reflect.TypeOf(zero).Elem()
 }
 
 // Cancel implements Operation.

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -2,6 +2,7 @@ package nexus
 
 import (
 	"context"
+	"reflect"
 )
 
 // UnimplementedHandler must be embedded into any [Handler] implementation for future compatibility.
@@ -39,6 +40,13 @@ type UnimplementedOperation[I, O any] struct{}
 func (*UnimplementedOperation[I, O]) inferType(I, O) {} //nolint:unused
 
 func (*UnimplementedOperation[I, O]) mustEmbedUnimplementedOperation() {}
+
+func (*UnimplementedOperation[I, O]) IsInputAssignable(i any) bool {
+	var zero [0]I
+	tt := reflect.TypeOf(zero).Elem()
+	it := reflect.TypeOf(i)
+	return it.AssignableTo(tt)
+}
 
 // Cancel implements Operation.
 func (*UnimplementedOperation[I, O]) Cancel(context.Context, string, CancelOperationOptions) error {


### PR DESCRIPTION
Useful helper methods, we need this in the Temporal Go SDK to validate inputs when starting an operation from a workflow.