### PR TITLE
Add Operation-Timeout header

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -29,6 +29,8 @@ const (
 
 	// HeaderRequestTimeout is the total time to complete a Nexus HTTP request.
 	HeaderRequestTimeout = "Request-Timeout"
+	// HeaderOperationTimeout is the total time to complete a Nexus operation.
+	HeaderOperationTimeout = "Operation-Timeout"
 )
 
 const contentTypeJSON = "application/json"


### PR DESCRIPTION
Added a new exported constant for the `Operation-Timeout` header.

Added logic to set the context deadline and outgoing `Request-Timeout` header to the minimum of the incoming `Request-Timeout` and `Operation-Timeout` if they are set.