### PR TITLE
Add OperationID, StartTime and StartLinks to CompletionRequest

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -22,18 +22,19 @@ const version = "v0.0.12"
 
 const (
 	// Nexus specific headers.
-	headerOperationState = "Nexus-Operation-State"
-	headerRequestID      = "Nexus-Request-Id"
-	headerLink           = "Nexus-Link"
+	headerOperationState     = "Nexus-Operation-State"
+	headerRequestID          = "Nexus-Request-Id"
+	headerLink               = "Nexus-Link"
+	headerOperationStartTime = "Nexus-Operation-Start-Time"
+	// HeaderOperationID is the unique ID returned by the StartOperation response for async operations.
+	// Must be set on callback headers to support completing operations before the start response is received.
+	HeaderOperationID = "Nexus-Operation-Id"
 
 	// HeaderRequestTimeout is the total time to complete a Nexus HTTP request.
 	HeaderRequestTimeout = "Request-Timeout"
 	// HeaderOperationTimeout is the total time to complete a Nexus operation.
 	// Unlike HeaderRequestTimeout, this applies to the whole operation, not just a single HTTP request.
 	HeaderOperationTimeout = "Operation-Timeout"
-	// HeaderOperationID is the unique ID returned by the StartOperation response for async operations.
-	// Must be set on callback headers to support completing operations before the start response is received.
-	HeaderOperationID = "Nexus-Operation-Id"
 )
 
 const contentTypeJSON = "application/json"

--- a/nexus/api.go
+++ b/nexus/api.go
@@ -18,12 +18,11 @@ import (
 )
 
 // Package version.
-const version = "v0.0.11"
+const version = "v0.0.12"
 
 const (
 	// Nexus specific headers.
 	headerOperationState = "Nexus-Operation-State"
-	headerOperationID    = "Nexus-Operation-Id"
 	headerRequestID      = "Nexus-Request-Id"
 	headerLink           = "Nexus-Link"
 
@@ -32,6 +31,9 @@ const (
 	// HeaderOperationTimeout is the total time to complete a Nexus operation.
 	// Unlike HeaderRequestTimeout, this applies to the whole operation, not just a single HTTP request.
 	HeaderOperationTimeout = "Operation-Timeout"
+	// HeaderOperationID is the unique ID returned by the StartOperation response for async operations.
+	// Must be set on callback headers to support completing operations before the start response is received.
+	HeaderOperationID = "Nexus-Operation-Id"
 )
 
 const contentTypeJSON = "application/json"

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -42,7 +42,7 @@ type OperationCompletionSuccessful struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are the links attached to the started response. Used when a completion callback is received before a started response.
+	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
 	StartLinks []Link
 }
 
@@ -55,7 +55,7 @@ type OperationCompletionSuccessfulOptions struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are the links attached to the started response. Used when a completion callback is received before a started response.
+	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
 	StartLinks []Link
 }
 
@@ -130,7 +130,7 @@ type OperationCompletionUnsuccessful struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are the links attached to the started response. Used when a completion callback is received before a started response.
+	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
 	StartLinks []Link
 	// Failure object to send with the completion.
 	Failure *Failure
@@ -173,7 +173,7 @@ type CompletionRequest struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are the links attached to the started response. Used when a completion callback is received before a started response.
+	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
 	StartLinks []Link
 	// Parsed from request and set if State is failed or canceled.
 	Failure *Failure

--- a/nexus/completion_test.go
+++ b/nexus/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,12 @@ func (h *successfulCompletionHandler) CompleteOperation(ctx context.Context, com
 	if completion.HTTPRequest.Header.Get("User-Agent") != userAgent {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'User-Agent' header: %q", completion.HTTPRequest.Header.Get("User-Agent"))
 	}
+	if completion.OperationID != "test-operation-id" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid %q header: %q", HeaderOperationID, completion.HTTPRequest.Header.Get(HeaderOperationID))
+	}
+	if len(completion.StartLinks) == 0 {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected StartLinks to be set on CompletionRequest")
+	}
 	var result int
 	err := completion.Result.Consume(&result)
 	if err != nil {
@@ -41,8 +48,19 @@ func TestSuccessfulCompletion(t *testing.T) {
 	ctx, callbackURL, teardown := setupForCompletion(t, &successfulCompletionHandler{}, nil)
 	defer teardown()
 
-	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{})
+	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{
+		StartLinks: []Link{{
+			URL: &url.URL{
+				Scheme:   "https",
+				Host:     "example.com",
+				Path:     "/path/to/something",
+				RawQuery: "param=value",
+			},
+			Type: "url",
+		}},
+	})
 	completion.Header.Add("foo", "bar")
+	completion.Header.Add(HeaderOperationID, "test-operation-id")
 	require.NoError(t, err)
 
 	request, err := NewCompletionHTTPRequest(ctx, callbackURL, completion)
@@ -55,15 +73,25 @@ func TestSuccessfulCompletion(t *testing.T) {
 	require.Equal(t, http.StatusOK, response.StatusCode)
 }
 
-func TestSuccessfulCompletion_CustomSerializr(t *testing.T) {
+func TestSuccessfulCompletion_CustomSerializer(t *testing.T) {
 	serializer := &customSerializer{}
 	ctx, callbackURL, teardown := setupForCompletion(t, &successfulCompletionHandler{}, serializer)
 	defer teardown()
 
 	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{
 		Serializer: serializer,
+		StartLinks: []Link{{
+			URL: &url.URL{
+				Scheme:   "https",
+				Host:     "example.com",
+				Path:     "/path/to/something",
+				RawQuery: "param=value",
+			},
+			Type: "url",
+		}},
 	})
 	completion.Header.Add("foo", "bar")
+	completion.Header.Add(HeaderOperationID, "test-operation-id")
 	require.NoError(t, err)
 
 	request, err := NewCompletionHTTPRequest(ctx, callbackURL, completion)
@@ -92,6 +120,12 @@ func (h *failureExpectingCompletionHandler) CompleteOperation(ctx context.Contex
 	if completion.HTTPRequest.Header.Get("foo") != "bar" {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'foo' header: %q", completion.HTTPRequest.Header.Get("foo"))
 	}
+	if completion.OperationID != "test-operation-id" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid %q header: %q", HeaderOperationID, completion.HTTPRequest.Header.Get(HeaderOperationID))
+	}
+	if len(completion.StartLinks) == 0 {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected StartLinks to be set on CompletionRequest")
+	}
 
 	return nil
 }
@@ -103,10 +137,20 @@ func TestFailureCompletion(t *testing.T) {
 	request, err := NewCompletionHTTPRequest(ctx, callbackURL, &OperationCompletionUnsuccessful{
 		Header: http.Header{"foo": []string{"bar"}},
 		State:  OperationStateCanceled,
+		StartLinks: []Link{{
+			URL: &url.URL{
+				Scheme:   "https",
+				Host:     "example.com",
+				Path:     "/path/to/something",
+				RawQuery: "param=value",
+			},
+			Type: "url",
+		}},
 		Failure: &Failure{
 			Message: "expected message",
 		},
 	})
+	request.Header.Add(HeaderOperationID, "test-operation-id")
 	require.NoError(t, err)
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)

--- a/nexus/completion_test.go
+++ b/nexus/completion_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,7 @@ func TestSuccessfulCompletion(t *testing.T) {
 	})
 	completion.Header.Add("foo", "bar")
 	completion.Header.Add(HeaderOperationID, "test-operation-id")
+	completion.Header.Add(headerOperationStartTime, time.Now().Format(http.TimeFormat))
 	require.NoError(t, err)
 
 	request, err := NewCompletionHTTPRequest(ctx, callbackURL, completion)

--- a/nexus/completion_test.go
+++ b/nexus/completion_test.go
@@ -125,6 +125,9 @@ func (h *failureExpectingCompletionHandler) CompleteOperation(ctx context.Contex
 	if completion.OperationID != "test-operation-id" {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid %q header: %q", HeaderOperationID, completion.HTTPRequest.Header.Get(HeaderOperationID))
 	}
+	if len(completion.StartLinks) == 0 {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected StartLinks to be set on CompletionRequest")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Added `OperationID`, `StartTime` and `StartLinks` fields to `CompletionRequest`. This information is necessary to fabricate a start event if the completion is received before the response to the StartOperation request.

Bumps SDK version to `0.0.12`