### PR TITLE
Make all header keys lower case and add Set utility

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -22,16 +22,16 @@ const version = "v0.0.11"
 
 const (
 	// Nexus specific headers.
-	headerOperationState = "Nexus-Operation-State"
-	headerOperationID    = "Nexus-Operation-Id"
-	headerRequestID      = "Nexus-Request-Id"
-	headerLink           = "Nexus-Link"
+	headerOperationState = "nexus-operation-state"
+	headerOperationID    = "nexus-operation-id"
+	headerRequestID      = "nexus-request-id"
+	headerLink           = "nexus-link"
 
 	// HeaderRequestTimeout is the total time to complete a Nexus HTTP request.
-	HeaderRequestTimeout = "Request-Timeout"
+	HeaderRequestTimeout = "request-timeout"
 	// HeaderOperationTimeout is the total time to complete a Nexus operation.
 	// Unlike HeaderRequestTimeout, this applies to the whole operation, not just a single HTTP request.
-	HeaderOperationTimeout = "Operation-Timeout"
+	HeaderOperationTimeout = "operation-timeout"
 )
 
 const contentTypeJSON = "application/json"
@@ -119,11 +119,17 @@ func isMediaTypeOctetStream(contentType string) bool {
 
 // Header is a mapping of string to string.
 // It is used throughout the framework to transmit metadata.
+// The keys should be in lower case form.
 type Header map[string]string
 
 // Get is a case-insensitive key lookup from the header map.
 func (h Header) Get(k string) string {
 	return h[strings.ToLower(k)]
+}
+
+// Set sets the header key to the given value transforming the key to its lower case form.
+func (h Header) Set(k, v string) {
+	h[strings.ToLower(k)] = v
 }
 
 func prefixStrippedHTTPHeaderToNexusHeader(httpHeader http.Header, prefix string) Header {

--- a/nexus/api_test.go
+++ b/nexus/api_test.go
@@ -3,6 +3,7 @@ package nexus
 import (
 	"encoding/json"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"reflect"
 	"testing"
@@ -99,7 +100,7 @@ func TestAddLinksToHeader(t *testing.T) {
 				Type: "url",
 			}},
 			output: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path/to/something?param=value>; type="url"`,
 				},
 			},
@@ -127,7 +128,7 @@ func TestAddLinksToHeader(t *testing.T) {
 				},
 			},
 			output: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path/to/something?param=value>; type="url"`,
 					`<https://foo.com/path/to/something?bar=value>; type="url"`,
 				},
@@ -174,7 +175,7 @@ func TestGetLinksFromHeader(t *testing.T) {
 		{
 			name: "single link",
 			input: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path/to/something?param=value>; type="url"`,
 				},
 			},
@@ -191,7 +192,7 @@ func TestGetLinksFromHeader(t *testing.T) {
 		{
 			name: "multiple links",
 			input: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path/to/something?param=value>; type="url"`,
 					`<https://foo.com/path/to/something?bar=value>; type="url"`,
 				},
@@ -220,7 +221,7 @@ func TestGetLinksFromHeader(t *testing.T) {
 		{
 			name: "multiple links single header",
 			input: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path/to/something?param=value>; type="url", <https://foo.com/path/to/something?bar=value>; type="url"`,
 				},
 			},
@@ -248,7 +249,7 @@ func TestGetLinksFromHeader(t *testing.T) {
 		{
 			name: "invalid header",
 			input: http.Header{
-				headerLink: []string{
+				textproto.CanonicalMIMEHeaderKey(headerLink): []string{
 					`<https://example.com/path?param=value> type="url"`,
 				},
 			},

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -94,7 +94,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 			request.URL.RawQuery = ""
 		}
 
-		response, err := h.sendGetOperationRequest(ctx, request)
+		response, err := h.sendGetOperationRequest(request)
 		if err != nil {
 			if wait > 0 && errors.Is(err, errOperationWaitTimeout) {
 				// TODO: Backoff a bit in case the server is continually returning timeouts due to some LB configuration
@@ -119,7 +119,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 	}
 }
 
-func (h *OperationHandle[T]) sendGetOperationRequest(ctx context.Context, request *http.Request) (*http.Response, error) {
+func (h *OperationHandle[T]) sendGetOperationRequest(request *http.Request) (*http.Response, error) {
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change copies what Go `http.Header` does but uses lower case as the canonical form.
Before this change, calling `nexus.Header{nexus.HeaderRequestTimeout: "1s"}` would produce an invalid header value.