### PR TITLE
Hide more HTTP details in the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ import (
 
 ### Client
 
-The Nexus Client is used to start operations and get [handles](#operationhandle) to existing, asynchronous operations.
+The Nexus HTTPClient is used to start operations and get [handles](#operationhandle) to existing, asynchronous operations.
 
-#### Create a Client
+#### Create an HTTPClient
 
 ```go
-client, err := nexus.NewClient(nexus.ClientOptions{
+client, err := nexus.NewHTTPClient(nexus.HTTPClientOptions{
 	BaseURL: "https://example.com/path/to/my/services",
 	Service: "example-service",
 })
@@ -86,7 +86,7 @@ result, err := client.StartOperation(ctx, "example", MyInput{Field: "value"}, ne
 
 #### Start an Operation and Await its Completion
 
-The Client provides the `ExecuteOperation` helper function as a shorthand for `StartOperation` and issuing a `GetResult`
+The HTTPClient provides the `ExecuteOperation` helper function as a shorthand for `StartOperation` and issuing a `GetResult`
 in case the operation is asynchronous.
 
 ```go
@@ -201,7 +201,7 @@ with the `NewOperationCompletionSuccessful` helper.
 Custom HTTP headers may be provided via `OperationCompletionSuccessful.Header`.
 
 ```go
-completion, _ := nexus.NewOperationCompletionSuccessful(MyStruct{Field: "value"})
+completion, _ := nexus.NewOperationCompletionSuccessful(MyStruct{Field: "value"}, OperationCompletionSuccessfulOptions{})
 request, _ := nexus.NewCompletionHTTPRequest(ctx, callbackURL, completion)
 response, _ := http.DefaultClient.Do(request)
 defer response.Body.Close()

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -46,10 +46,12 @@ var errOperationWaitTimeout = errors.New("operation wait timeout")
 type UnexpectedResponseError struct {
 	// Error message.
 	Message string
-	// The HTTP response. The response body will have already been read into memory and does not need to be closed.
-	Response *http.Response
-	// Optional failure that may have been emedded in the HTTP response body.
+	// Optional failure that may have been emedded in the response.
 	Failure *Failure
+	// Additional transport specific details.
+	// For HTTP, this would include the HTTP response. The response body will have already been read into memory and
+	// does not need to be closed.
+	Details any
 }
 
 // Error implements the error interface.
@@ -66,9 +68,9 @@ func newUnexpectedResponseError(message string, response *http.Response, body []
 	}
 
 	return &UnexpectedResponseError{
-		Message:  message,
-		Response: response,
-		Failure:  failure,
+		Message: message,
+		Details: response,
+		Failure: failure,
 	}
 }
 

--- a/nexus/client_example_test.go
+++ b/nexus/client_example_test.go
@@ -13,7 +13,7 @@ type MyStruct struct {
 }
 
 var ctx = context.Background()
-var client *nexus.Client
+var client *nexus.HTTPClient
 
 func ExampleClient_StartOperation() {
 	result, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})

--- a/nexus/client_example_test.go
+++ b/nexus/client_example_test.go
@@ -15,7 +15,7 @@ type MyStruct struct {
 var ctx = context.Background()
 var client *nexus.HTTPClient
 
-func ExampleClient_StartOperation() {
+func ExampleHTTPClient_StartOperation() {
 	result, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})
 	if err != nil {
 		var unsuccessfulOperationError *nexus.UnsuccessfulOperationError
@@ -40,7 +40,7 @@ func ExampleClient_StartOperation() {
 	}
 }
 
-func ExampleClient_ExecuteOperation() {
+func ExampleHTTPClient_ExecuteOperation() {
 	response, err := client.ExecuteOperation(ctx, "operation name", MyStruct{Field: "value"}, nexus.ExecuteOperationOptions{})
 	if err != nil {
 		// handle nexus.UnsuccessfulOperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded

--- a/nexus/client_test.go
+++ b/nexus/client_test.go
@@ -10,22 +10,22 @@ import (
 func TestNewClient(t *testing.T) {
 	var err error
 
-	_, err = NewClient(ClientOptions{BaseURL: "", Service: "ignored"})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "", Service: "ignored"})
 	require.ErrorContains(t, err, "empty BaseURL")
 
-	_, err = NewClient(ClientOptions{BaseURL: "-http://invalid", Service: "ignored"})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "-http://invalid", Service: "ignored"})
 	var urlError *url.Error
 	require.ErrorAs(t, err, &urlError)
 
-	_, err = NewClient(ClientOptions{BaseURL: "smtp://example.com", Service: "ignored"})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "smtp://example.com", Service: "ignored"})
 	require.ErrorContains(t, err, "invalid URL scheme: smtp")
 
-	_, err = NewClient(ClientOptions{BaseURL: "http://example.com", Service: "ignored"})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "http://example.com", Service: "ignored"})
 	require.NoError(t, err)
 
-	_, err = NewClient(ClientOptions{BaseURL: "https://example.com", Service: ""})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "https://example.com", Service: ""})
 	require.ErrorContains(t, err, "empty Service")
 
-	_, err = NewClient(ClientOptions{BaseURL: "https://example.com", Service: "valid"})
+	_, err = NewHTTPClient(HTTPClientOptions{BaseURL: "https://example.com", Service: "valid"})
 	require.NoError(t, err)
 }

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -46,8 +46,8 @@ type OperationCompletionSuccessful struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
-	StartLinks []Link
+	// Links are used to link back to the operation when a completion callback is received before a started response.
+	Links []Link
 }
 
 // OperationCompletionSuccessfulOptions are options for [NewOperationCompletionSuccessful].
@@ -59,8 +59,8 @@ type OperationCompletionSuccessfulOptions struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
-	StartLinks []Link
+	// Links are used to link back to the operation when a completion callback is received before a started response.
+	Links []Link
 }
 
 // NewOperationCompletionSuccessful constructs an [OperationCompletionSuccessful] from a given result.
@@ -96,7 +96,7 @@ func NewOperationCompletionSuccessful(result any, options OperationCompletionSuc
 		Reader:      reader,
 		OperationID: options.OperationID,
 		StartTime:   options.StartTime,
-		StartLinks:  options.StartLinks,
+		Links:       options.Links,
 	}, nil
 }
 
@@ -118,7 +118,7 @@ func (c *OperationCompletionSuccessful) applyToHTTPRequest(request *http.Request
 		request.Header.Set(headerOperationStartTime, c.StartTime.Format(http.TimeFormat))
 	}
 	if c.Header.Get(headerLink) == "" {
-		if err := addLinksToHTTPHeader(c.StartLinks, request.Header); err != nil {
+		if err := addLinksToHTTPHeader(c.Links, request.Header); err != nil {
 			return err
 		}
 	}
@@ -139,8 +139,8 @@ type OperationCompletionUnsuccessful struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
-	StartLinks []Link
+	// Links are used to link back to the operation when a completion callback is received before a started response.
+	Links []Link
 	// Failure object to send with the completion.
 	Failure *Failure
 }
@@ -161,7 +161,7 @@ func (c *OperationCompletionUnsuccessful) applyToHTTPRequest(request *http.Reque
 		request.Header.Set(headerOperationStartTime, c.StartTime.Format(http.TimeFormat))
 	}
 	if c.Header.Get(headerLink) == "" {
-		if err := addLinksToHTTPHeader(c.StartLinks, request.Header); err != nil {
+		if err := addLinksToHTTPHeader(c.Links, request.Header); err != nil {
 			return err
 		}
 	}

--- a/nexus/completion_test.go
+++ b/nexus/completion_test.go
@@ -51,7 +51,7 @@ func TestSuccessfulCompletion(t *testing.T) {
 	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{
 		OperationID: "test-operation-id",
 		StartTime:   time.Now(),
-		StartLinks: []Link{{
+		Links: []Link{{
 			URL: &url.URL{
 				Scheme:   "https",
 				Host:     "example.com",
@@ -81,7 +81,7 @@ func TestSuccessfulCompletion_CustomSerializer(t *testing.T) {
 
 	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{
 		Serializer: serializer,
-		StartLinks: []Link{{
+		Links: []Link{{
 			URL: &url.URL{
 				Scheme:   "https",
 				Host:     "example.com",
@@ -140,7 +140,7 @@ func TestFailureCompletion(t *testing.T) {
 		State:       OperationStateCanceled,
 		OperationID: "test-operation-id",
 		StartTime:   time.Now(),
-		StartLinks: []Link{{
+		Links: []Link{{
 			URL: &url.URL{
 				Scheme:   "https",
 				Host:     "example.com",

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -16,7 +16,7 @@ type OperationHandle[T any] struct {
 	Operation string
 	// Handler generated ID for this handle's operation.
 	ID     string
-	client *Client
+	client *HTTPClient
 }
 
 // GetInfo gets operation information, issuing a network request to the service handler.

--- a/nexus/handle_test.go
+++ b/nexus/handle_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewHandleFailureConditions(t *testing.T) {
-	client, err := NewClient(ClientOptions{BaseURL: "http://foo.com", Service: "test"})
+	client, err := NewHTTPClient(HTTPClientOptions{BaseURL: "http://foo.com", Service: "test"})
 	require.NoError(t, err)
 	_, err = client.NewHandle("", "id")
 	require.ErrorIs(t, err, errEmptyOperationName)

--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -316,13 +316,13 @@ func (r *registryHandler) StartOperation(ctx context.Context, service, operation
 
 var _ Handler = &registryHandler{}
 
-// ExecuteOperation is the type safe version of [Client.ExecuteOperation].
+// ExecuteOperation is the type safe version of [HTTPClient.ExecuteOperation].
 // It accepts input of type I and returns output of type O, removing the need to consume the [LazyValue] returned by the
 // client method.
 //
 //	ref := NewOperationReference[MyInput, MyOutput]("my-operation")
 //	out, err := ExecuteOperation(ctx, client, ref, MyInput{}, options) // returns MyOutput, error
-func ExecuteOperation[I, O any](ctx context.Context, client *Client, operation OperationReference[I, O], input I, request ExecuteOperationOptions) (O, error) {
+func ExecuteOperation[I, O any](ctx context.Context, client *HTTPClient, operation OperationReference[I, O], input I, request ExecuteOperationOptions) (O, error) {
 	var o O
 	value, err := client.ExecuteOperation(ctx, operation.Name(), input, request)
 	if err != nil {
@@ -331,10 +331,10 @@ func ExecuteOperation[I, O any](ctx context.Context, client *Client, operation O
 	return o, value.Consume(&o)
 }
 
-// StartOperation is the type safe version of [Client.StartOperation].
+// StartOperation is the type safe version of [HTTPClient.StartOperation].
 // It accepts input of type I and returns a [ClientStartOperationResult] of type O, removing the need to consume the
 // [LazyValue] returned by the client method.
-func StartOperation[I, O any](ctx context.Context, client *Client, operation OperationReference[I, O], input I, request StartOperationOptions) (*ClientStartOperationResult[O], error) {
+func StartOperation[I, O any](ctx context.Context, client *HTTPClient, operation OperationReference[I, O], input I, request StartOperationOptions) (*ClientStartOperationResult[O], error) {
 	result, err := client.StartOperation(ctx, operation.Name(), input, request)
 	if err != nil {
 		return nil, err
@@ -353,9 +353,9 @@ func StartOperation[I, O any](ctx context.Context, client *Client, operation Ope
 	}, nil
 }
 
-// NewHandle is the type safe version of [Client.NewHandle].
+// NewHandle is the type safe version of [HTTPClient.NewHandle].
 // The [Handle.GetResult] method will return an output of type O.
-func NewHandle[I, O any](client *Client, operation OperationReference[I, O], operationID string) (*OperationHandle[O], error) {
+func NewHandle[I, O any](client *HTTPClient, operation OperationReference[I, O], operationID string) (*OperationHandle[O], error) {
 	if operationID == "" {
 		return nil, errEmptyOperationID
 	}

--- a/nexus/serializer.go
+++ b/nexus/serializer.go
@@ -69,7 +69,7 @@ func (l *LazyValue) Consume(v any) error {
 
 // Serializer is used by the framework to serialize/deserialize input and output.
 // To customize serialization logic, implement this interface and provide your implementation to framework methods such
-// as [NewClient] and [NewHTTPHandler].
+// as [NewHTTPClient] and [NewHTTPHandler].
 // By default, the SDK supports serialization of JSONables, byte slices, and nils.
 type Serializer interface {
 	// Serialize encodes a value into a [Content].

--- a/nexus/setup_test.go
+++ b/nexus/setup_test.go
@@ -15,7 +15,7 @@ const testTimeout = time.Second * 5
 const testService = "Ser/vic e"
 const getResultMaxTimeout = time.Millisecond * 300
 
-func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx context.Context, client *Client, teardown func()) {
+func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx context.Context, client *HTTPClient, teardown func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 
 	httpHandler := NewHTTPHandler(HandlerOptions{
@@ -26,7 +26,7 @@ func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx 
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
-	client, err = NewClient(ClientOptions{
+	client, err = NewHTTPClient(HTTPClientOptions{
 		BaseURL:    fmt.Sprintf("http://%s/", listener.Addr().String()),
 		Service:    testService,
 		Serializer: serializer,
@@ -44,7 +44,7 @@ func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx 
 	}
 }
 
-func setup(t *testing.T, handler Handler) (ctx context.Context, client *Client, teardown func()) {
+func setup(t *testing.T, handler Handler) (ctx context.Context, client *HTTPClient, teardown func()) {
 	return setupSerializer(t, handler, nil)
 }
 


### PR DESCRIPTION
Before we release a stable API, we'd like to hide as much of the HTTP details from the public API.

Changes:

- Rename `Client` to `HTTPClient`
- Rename `ClientOptions` to `HTTPClientOptions`
- Rename `NewClient` to `NewHTTPClient`
- Hide `http.Response` from `UnexpectedResponseError`, it can now be obtained by casting the `Details` field
- `OperationCompletionSuccessful` now uses `nexus.Header` and `nexus.Reader` instead of `http.Header` and `io.Reader`
- `OperationCompletionUnsuccessul` now uses a `nexus.Header` instead of `http.Header`
- Rename `OperationCompletion(Un)Successful(Options)` `StartLinks` to `Links`

💥 **This is a breaking change** and requires a semver minor bump (we're still in 0 minor version) before release.