### PR TITLE
Failure Converter

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -65,6 +65,18 @@ type Failure struct {
 	Details json.RawMessage `json:"details,omitempty"`
 }
 
+// An error that directly represents a wire representation of [Failure].
+// The SDK will convert to this error by default unless the [FailureConverter] instance is customized.
+type FailureError struct {
+	// The underlying Failure object this error represents.
+	Failure Failure
+}
+
+// Error implements the error interface.
+func (e *FailureError) Error() string {
+	return e.Failure.Message
+}
+
 // UnsuccessfulOperationError represents "failed" and "canceled" operation results.
 type UnsuccessfulOperationError struct {
 	// State of the operation. Only [OperationStateFailed] and [OperationStateCanceled] are valid.

--- a/nexus/api.go
+++ b/nexus/api.go
@@ -96,7 +96,7 @@ func (e *UnsuccessfulOperationError) Error() string {
 	if e.Cause == nil {
 		return fmt.Sprintf("operation %s", e.State)
 	}
-	return fmt.Sprintf("operation %s: %s", e.State, e.Error())
+	return fmt.Sprintf("operation %s: %s", e.State, e.Cause.Error())
 }
 
 // Unwrap returns the cause for use with utilities in the errors package.

--- a/nexus/api.go
+++ b/nexus/api.go
@@ -70,8 +70,7 @@ type UnsuccessfulOperationError struct {
 	// State of the operation. Only [OperationStateFailed] and [OperationStateCanceled] are valid.
 	State OperationState
 	// The underlying cause for this error.
-	Cause      error
-	rawFailure *Failure
+	Cause error
 }
 
 // NewFailedOperationError is shorthand for constructing an [UnsuccessfulOperationError] with State set to

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -29,8 +29,8 @@ type HTTPClientOptions struct {
 	// A [Serializer] to customize client serialization behavior.
 	// By default the client handles JSONables, byte slices, and nil.
 	Serializer Serializer
-	// A [FailureConverter] to convert a [Failure] instance to and from an [error].
-	// By default the client translates only error messages, losing type information and struct fields.
+	// A [FailureConverter] to convert a [Failure] instance to and from an [error]. Defaults to
+	// [DefaultFailureConverter].
 	FailureConverter FailureConverter
 }
 

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -280,9 +280,8 @@ func (c *HTTPClient) StartOperation(
 
 		failureErr := c.options.FailureConverter.FailureToError(failure)
 		return nil, &UnsuccessfulOperationError{
-			State:      state,
-			Cause:      failureErr,
-			rawFailure: &failure,
+			State: state,
+			Cause: failureErr,
 		}
 	default:
 		return nil, c.bestEffortHandlerErrorFromResponse(response, body)
@@ -418,41 +417,41 @@ func (c *HTTPClient) failureFromResponseOrDefault(response *http.Response, body 
 	return failure
 }
 
-func (c *HTTPClient) failureErrorFromResponseOrDefault(response *http.Response, body []byte, defaultMessage string) (Failure, error) {
+func (c *HTTPClient) failureErrorFromResponseOrDefault(response *http.Response, body []byte, defaultMessage string) error {
 	failure := c.failureFromResponseOrDefault(response, body, defaultMessage)
 	failureErr := c.options.FailureConverter.FailureToError(failure)
-	return failure, failureErr
+	return failureErr
 }
 
 func (c *HTTPClient) bestEffortHandlerErrorFromResponse(response *http.Response, body []byte) error {
 	switch response.StatusCode {
 	case http.StatusBadRequest:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "bad request")
-		return &HandlerError{Type: HandlerErrorTypeBadRequest, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "bad request")
+		return &HandlerError{Type: HandlerErrorTypeBadRequest, Cause: failureErr}
 	case http.StatusUnauthorized:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "unauthenticated")
-		return &HandlerError{Type: HandlerErrorTypeUnauthenticated, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "unauthenticated")
+		return &HandlerError{Type: HandlerErrorTypeUnauthenticated, Cause: failureErr}
 	case http.StatusForbidden:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "unauthorized")
-		return &HandlerError{Type: HandlerErrorTypeUnauthorized, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "unauthorized")
+		return &HandlerError{Type: HandlerErrorTypeUnauthorized, Cause: failureErr}
 	case http.StatusNotFound:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "not found")
-		return &HandlerError{Type: HandlerErrorTypeNotFound, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "not found")
+		return &HandlerError{Type: HandlerErrorTypeNotFound, Cause: failureErr}
 	case http.StatusTooManyRequests:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "resource exhausted")
-		return &HandlerError{Type: HandlerErrorTypeResourceExhausted, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "resource exhausted")
+		return &HandlerError{Type: HandlerErrorTypeResourceExhausted, Cause: failureErr}
 	case http.StatusInternalServerError:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "internal error")
-		return &HandlerError{Type: HandlerErrorTypeInternal, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "internal error")
+		return &HandlerError{Type: HandlerErrorTypeInternal, Cause: failureErr}
 	case http.StatusNotImplemented:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "not implemented")
-		return &HandlerError{Type: HandlerErrorTypeNotImplemented, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "not implemented")
+		return &HandlerError{Type: HandlerErrorTypeNotImplemented, Cause: failureErr}
 	case http.StatusServiceUnavailable:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "unavailable")
-		return &HandlerError{Type: HandlerErrorTypeUnavailable, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "unavailable")
+		return &HandlerError{Type: HandlerErrorTypeUnavailable, Cause: failureErr}
 	case StatusUpstreamTimeout:
-		failure, failureErr := c.failureErrorFromResponseOrDefault(response, body, "upstream timeout")
-		return &HandlerError{Type: HandlerErrorTypeUpstreamTimeout, Cause: failureErr, rawFailure: &failure}
+		failureErr := c.failureErrorFromResponseOrDefault(response, body, "upstream timeout")
+		return &HandlerError{Type: HandlerErrorTypeUpstreamTimeout, Cause: failureErr}
 	default:
 		return newUnexpectedResponseError(fmt.Sprintf("unexpected response status: %q", response.Status), response, body)
 	}

--- a/nexus/client_example_test.go
+++ b/nexus/client_example_test.go
@@ -20,11 +20,11 @@ func ExampleHTTPClient_StartOperation() {
 	if err != nil {
 		var unsuccessfulOperationError *nexus.UnsuccessfulOperationError
 		if errors.As(err, &unsuccessfulOperationError) { // operation failed or canceled
-			fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Failure.Message)
+			fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Cause.Error())
 		}
 		var handlerError *nexus.HandlerError
 		if errors.As(err, &handlerError) {
-			fmt.Printf("Handler returned an error, type: %s, failure message: %s\n", handlerError.Type, handlerError.Failure.Message)
+			fmt.Printf("Handler returned an error, type: %s, failure message: %s\n", handlerError.Type, handlerError.Cause.Error())
 		}
 		// most other errors should be returned as *nexus.UnexpectedResponseError
 	}

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -142,7 +142,36 @@ type OperationCompletionUnsuccessful struct {
 	// Links are used to link back to the operation when a completion callback is received before a started response.
 	Links []Link
 	// Failure object to send with the completion.
-	Failure *Failure
+	Failure Failure
+}
+
+// OperationCompletionUnsuccessfulOptions are options for [NewOperationCompletionUnsuccessful].
+type OperationCompletionUnsuccessfulOptions struct {
+	// Optional failure converter for converting errors to [Failure] objects. Defaults to the SDK's default
+	// FailureConverter, which translates only error messages losing type information and struct fields.
+	FailureConverter FailureConverter
+	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	OperationID string
+	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
+	StartTime time.Time
+	// Links are used to link back to the operation when a completion callback is received before a started response.
+	Links []Link
+}
+
+// NewOperationCompletionUnsuccessful constructs an [OperationCompletionUnsuccessful] from a given error.
+func NewOperationCompletionUnsuccessful(error *UnsuccessfulOperationError, options OperationCompletionUnsuccessfulOptions) (*OperationCompletionUnsuccessful, error) {
+	if options.FailureConverter == nil {
+		options.FailureConverter = defaultFailureConverter
+	}
+
+	return &OperationCompletionUnsuccessful{
+		Header:      make(Header),
+		State:       error.State,
+		Failure:     options.FailureConverter.ErrorToFailure(error.Cause),
+		OperationID: options.OperationID,
+		StartTime:   options.StartTime,
+		Links:       options.Links,
+	}, nil
 }
 
 func (c *OperationCompletionUnsuccessful) applyToHTTPRequest(request *http.Request) error {
@@ -185,10 +214,10 @@ type CompletionRequest struct {
 	OperationID string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
-	// StartLinks are used to link back to the operation when a completion callback is received before a started response.
-	StartLinks []Link
+	// Links are used to link back to the operation when a completion callback is received before a started response.
+	Links []Link
 	// Parsed from request and set if State is failed or canceled.
-	Failure *Failure
+	Error error
 	// Extracted from request and set if State is succeeded.
 	Result *LazyValue
 }
@@ -209,6 +238,9 @@ type CompletionHandlerOptions struct {
 	// A [Serializer] to customize handler serialization behavior.
 	// By default the handler handles, JSONables, byte slices, and nil.
 	Serializer Serializer
+	// A [FailureConverter] to convert a [Failure] instance to and from an [error].
+	// By default the client translates only error messages, losing type information and struct fields.
+	FailureConverter FailureConverter
 }
 
 type completionHTTPHandler struct {
@@ -231,7 +263,7 @@ func (h *completionHTTPHandler) ServeHTTP(writer http.ResponseWriter, request *h
 		}
 	}
 	var decodeErr error
-	if completion.StartLinks, decodeErr = getLinksFromHeader(request.Header); decodeErr != nil {
+	if completion.Links, decodeErr = getLinksFromHeader(request.Header); decodeErr != nil {
 		h.writeFailure(writer, HandlerErrorf(HandlerErrorTypeBadRequest, "failed to decode links from request headers"))
 		return
 	}
@@ -251,7 +283,7 @@ func (h *completionHTTPHandler) ServeHTTP(writer http.ResponseWriter, request *h
 			h.writeFailure(writer, HandlerErrorf(HandlerErrorTypeBadRequest, "failed to read Failure from request body"))
 			return
 		}
-		completion.Failure = &failure
+		completion.Error = h.failureConverter.FailureToError(failure)
 	case OperationStateSucceeded:
 		completion.Result = &LazyValue{
 			serializer: h.options.Serializer,
@@ -277,10 +309,14 @@ func NewCompletionHTTPHandler(options CompletionHandlerOptions) http.Handler {
 	if options.Serializer == nil {
 		options.Serializer = defaultSerializer
 	}
+	if options.FailureConverter == nil {
+		options.FailureConverter = defaultFailureConverter
+	}
 	return &completionHTTPHandler{
 		options: options,
 		baseHTTPHandler: baseHTTPHandler{
-			logger: options.Logger,
+			logger:           options.Logger,
+			failureConverter: options.FailureConverter,
 		},
 	}
 }

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -147,8 +147,8 @@ type OperationCompletionUnsuccessful struct {
 
 // OperationCompletionUnsuccessfulOptions are options for [NewOperationCompletionUnsuccessful].
 type OperationCompletionUnsuccessfulOptions struct {
-	// Optional failure converter for converting errors to [Failure] objects. Defaults to the SDK's default
-	// FailureConverter, which translates only error messages losing type information and struct fields.
+	// A [FailureConverter] to convert a [Failure] instance to and from an [error]. Defaults to
+	// [DefaultFailureConverter].
 	FailureConverter FailureConverter
 	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
 	OperationID string
@@ -238,8 +238,8 @@ type CompletionHandlerOptions struct {
 	// A [Serializer] to customize handler serialization behavior.
 	// By default the handler handles, JSONables, byte slices, and nil.
 	Serializer Serializer
-	// A [FailureConverter] to convert a [Failure] instance to and from an [error].
-	// By default the client translates only error messages, losing type information and struct fields.
+	// A [FailureConverter] to convert a [Failure] instance to and from an [error]. Defaults to
+	// [DefaultFailureConverter].
 	FailureConverter FailureConverter
 }
 

--- a/nexus/get_result_test.go
+++ b/nexus/get_result_test.go
@@ -149,7 +149,7 @@ func TestWaitResult_RequestTimeout(t *testing.T) {
 	require.NotNil(t, handle)
 
 	timeout := 200 * time.Millisecond
-	deadline := time.Now().Add(200 * time.Millisecond)
+	deadline := time.Now().Add(timeout)
 	_, err = handle.GetResult(ctx, GetOperationResultOptions{Wait: time.Second, Header: Header{HeaderRequestTimeout: formatDuration(timeout)}})
 	require.ErrorIs(t, err, ErrOperationStillRunning)
 	require.WithinDuration(t, deadline, handler.requests[0].deadline, 1*time.Millisecond)

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -151,9 +151,8 @@ func (h *OperationHandle[T]) sendGetOperationRequest(request *http.Request) (*ht
 		}
 		failureErr := h.client.options.FailureConverter.FailureToError(failure)
 		return nil, &UnsuccessfulOperationError{
-			State:      state,
-			Cause:      failureErr,
-			rawFailure: &failure,
+			State: state,
+			Cause: failureErr,
 		}
 	default:
 		return nil, h.client.bestEffortHandlerErrorFromResponse(response, body)

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -94,7 +94,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 			request.URL.RawQuery = ""
 		}
 
-		response, err := h.sendGetOperationRequest(request)
+		response, err := h.sendGetOperationResultRequest(request)
 		if err != nil {
 			if wait > 0 && errors.Is(err, errOperationWaitTimeout) {
 				// TODO: Backoff a bit in case the server is continually returning timeouts due to some LB configuration
@@ -119,7 +119,7 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 	}
 }
 
-func (h *OperationHandle[T]) sendGetOperationRequest(request *http.Request) (*http.Response, error) {
+func (h *OperationHandle[T]) sendGetOperationResultRequest(request *http.Request) (*http.Response, error) {
 	response, err := h.client.options.HTTPCaller(request)
 	if err != nil {
 		return nil, err

--- a/nexus/handler_example_test.go
+++ b/nexus/handler_example_test.go
@@ -46,14 +46,14 @@ func (h *myHandler) GetOperationResult(ctx context.Context, service, operation, 
 			}
 			// Optionally translate to operation failure (could also result in canceled state).
 			// Optionally expose the error details to the caller.
-			return nil, &nexus.UnsuccessfulOperationError{State: nexus.OperationStateFailed, Failure: nexus.Failure{Message: err.Error()}}
+			return nil, nexus.NewFailedOperationError(err)
 		}
 		return result, nil
 	} else {
 		result, err := h.peekOperation(ctx)
 		if err != nil {
 			// Optionally translate to operation failure (could also result in canceled state).
-			return nil, &nexus.UnsuccessfulOperationError{State: nexus.OperationStateFailed, Failure: nexus.Failure{Message: err.Error()}}
+			return nil, nexus.NewFailedOperationError(err)
 		}
 		return result, nil
 	}
@@ -80,7 +80,7 @@ func (h *myHandler) peekOperation(ctx context.Context) (*MyResult, error) {
 func (h *myHandler) authorize(ctx context.Context, header nexus.Header) error {
 	// Authorization for demo purposes
 	if header.Get("Authorization") != "Bearer top-secret" {
-		return &nexus.HandlerError{Type: nexus.HandlerErrorTypeUnauthorized, Failure: &nexus.Failure{Message: "Unauthorized"}}
+		return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "unauthorized")
 	}
 	return nil
 }

--- a/nexus/handler_example_test.go
+++ b/nexus/handler_example_test.go
@@ -77,7 +77,7 @@ func (h *myHandler) peekOperation(ctx context.Context) (*MyResult, error) {
 	panic("unimplemented")
 }
 
-func (h *myHandler) authorize(ctx context.Context, header nexus.Header) error {
+func (h *myHandler) authorize(_ context.Context, header nexus.Header) error {
 	// Authorization for demo purposes
 	if header.Get("Authorization") != "Bearer top-secret" {
 		return nexus.HandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "unauthorized")

--- a/nexus/serializer_test.go
+++ b/nexus/serializer_test.go
@@ -161,8 +161,24 @@ func TestCustomSerializer(t *testing.T) {
 	require.Equal(t, 4, c.encoded)
 }
 
-func TestDefaultFailureConverter(t *testing.T) {
+func TestDefaultFailureConverterArbitraryError(t *testing.T) {
 	sourceErr := errors.New("test")
+	var f Failure
+	conv := defaultFailureConverter
+
+	f = conv.ErrorToFailure(sourceErr)
+	convErr := conv.FailureToError(f)
+	require.Equal(t, sourceErr.Error(), convErr.Error())
+}
+
+func TestDefaultFailureConverterFailureError(t *testing.T) {
+	sourceErr := &FailureError{
+		Failure: Failure{
+			Message:  "test",
+			Metadata: map[string]string{"key": "value"},
+			Details:  []byte(`"details"`),
+		},
+	}
 	var f Failure
 	conv := defaultFailureConverter
 

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -131,10 +131,19 @@ const (
 // HandlerError is a special error that can be returned from [Handler] methods for failing a request with a custom
 // status code and failure message.
 type HandlerError struct {
-	// Defaults to HandlerErrorTypeInternal
+	// Error Type. Defaults to HandlerErrorTypeInternal.
 	Type HandlerErrorType
-	// Failure to report back in the response. Optional.
-	Failure *Failure
+	// The underlying cause for this error.
+	Cause      error
+	rawFailure *Failure
+}
+
+// HandlerErrorf creates a [HandlerError] with the given type using [fmt.Errorf] to construct the cause.
+func HandlerErrorf(typ HandlerErrorType, format string, args ...any) *HandlerError {
+	return &HandlerError{
+		Type:  typ,
+		Cause: fmt.Errorf(format, args...),
+	}
 }
 
 // Error implements the error interface.
@@ -143,24 +152,20 @@ func (e *HandlerError) Error() string {
 	if len(typ) == 0 {
 		typ = HandlerErrorTypeInternal
 	}
-	if e.Failure != nil {
-		return fmt.Sprintf("handler error (%s): %s", typ, e.Failure.Message)
+	if e.Cause == nil {
+		return fmt.Sprintf("handler error (%s)", typ)
 	}
-	return fmt.Sprintf("handler error (%s)", typ)
+	return fmt.Sprintf("handler error (%s): %s", typ, e.Cause.Error())
 }
 
-// HandlerErrorf creates a [HandlerError] with the given type and a formatted failure message.
-func HandlerErrorf(typ HandlerErrorType, format string, args ...any) *HandlerError {
-	return &HandlerError{
-		Type: typ,
-		Failure: &Failure{
-			Message: fmt.Sprintf(format, args...),
-		},
-	}
+// Unwrap returns the cause for use with utilities in the errors package.
+func (e *HandlerError) Unwrap() error {
+	return e.Cause
 }
 
 type baseHTTPHandler struct {
-	logger *slog.Logger
+	logger           *slog.Logger
+	failureConverter FailureConverter
 }
 
 type httpHandler struct {
@@ -205,7 +210,7 @@ func (h *httpHandler) writeResult(writer http.ResponseWriter, result any) {
 }
 
 func (h *baseHTTPHandler) writeFailure(writer http.ResponseWriter, err error) {
-	var failure *Failure
+	var failure Failure
 	var unsuccessfulError *UnsuccessfulOperationError
 	var handlerError *HandlerError
 	var operationState OperationState
@@ -213,7 +218,7 @@ func (h *baseHTTPHandler) writeFailure(writer http.ResponseWriter, err error) {
 
 	if errors.As(err, &unsuccessfulError) {
 		operationState = unsuccessfulError.State
-		failure = &unsuccessfulError.Failure
+		failure = h.failureConverter.ErrorToFailure(unsuccessfulError.Cause)
 		statusCode = statusOperationFailed
 
 		if operationState == OperationStateFailed || operationState == OperationStateCanceled {
@@ -224,7 +229,7 @@ func (h *baseHTTPHandler) writeFailure(writer http.ResponseWriter, err error) {
 			return
 		}
 	} else if errors.As(err, &handlerError) {
-		failure = handlerError.Failure
+		failure = h.failureConverter.ErrorToFailure(handlerError.Cause)
 		switch handlerError.Type {
 		case HandlerErrorTypeBadRequest:
 			statusCode = http.StatusBadRequest
@@ -248,22 +253,19 @@ func (h *baseHTTPHandler) writeFailure(writer http.ResponseWriter, err error) {
 			h.logger.Error("unexpected handler error type", "type", handlerError.Type)
 		}
 	} else {
-		failure = &Failure{
+		failure = Failure{
 			Message: "internal server error",
 		}
 		h.logger.Error("handler failed", "error", err)
 	}
 
-	var bytes []byte
-	if failure != nil {
-		bytes, err = json.Marshal(failure)
-		if err != nil {
-			h.logger.Error("failed to marshal failure", "error", err)
-			writer.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		writer.Header().Set("Content-Type", contentTypeJSON)
+	bytes, err := json.Marshal(failure)
+	if err != nil {
+		h.logger.Error("failed to marshal failure", "error", err)
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
 	}
+	writer.Header().Set("Content-Type", contentTypeJSON)
 
 	writer.WriteHeader(statusCode)
 
@@ -439,8 +441,11 @@ type HandlerOptions struct {
 	// Defaults to one minute.
 	GetResultTimeout time.Duration
 	// A [Serializer] to customize handler serialization behavior.
-	// By default the handler handles, JSONables, byte slices, and nil.
+	// By default the handler handles JSONables, byte slices, and nil.
 	Serializer Serializer
+	// A [FailureConverter] to convert a [Failure] instance to and from an [error].
+	// By default the client translates only error messages, losing type information and struct fields.
+	FailureConverter FailureConverter
 }
 
 func (h *httpHandler) handleRequest(writer http.ResponseWriter, request *http.Request) {
@@ -515,9 +520,13 @@ func NewHTTPHandler(options HandlerOptions) http.Handler {
 	if options.Serializer == nil {
 		options.Serializer = defaultSerializer
 	}
+	if options.FailureConverter == nil {
+		options.FailureConverter = defaultFailureConverter
+	}
 	handler := &httpHandler{
 		baseHTTPHandler: baseHTTPHandler{
-			logger: options.Logger,
+			logger:           options.Logger,
+			failureConverter: options.FailureConverter,
 		},
 		options: options,
 	}

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -443,7 +443,7 @@ type HandlerOptions struct {
 	// By default the handler handles JSONables, byte slices, and nil.
 	Serializer Serializer
 	// A [FailureConverter] to convert a [Failure] instance to and from an [error].
-	// By default the client translates only error messages, losing type information and struct fields.
+	// Defaults to [DefaultFailureConverter].
 	FailureConverter FailureConverter
 }
 

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -134,8 +134,7 @@ type HandlerError struct {
 	// Error Type. Defaults to HandlerErrorTypeInternal.
 	Type HandlerErrorType
 	// The underlying cause for this error.
-	Cause      error
-	rawFailure *Failure
+	Cause error
 }
 
 // HandlerErrorf creates a [HandlerError] with the given type using [fmt.Errorf] to construct the cause.

--- a/nexus/server_test.go
+++ b/nexus/server_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestWriteFailure_GenericError(t *testing.T) {
 	h := baseHTTPHandler{
-		logger: slog.Default(),
+		logger:           slog.Default(),
+		failureConverter: defaultFailureConverter,
 	}
 
 	writer := httptest.NewRecorder()
@@ -29,7 +30,8 @@ func TestWriteFailure_GenericError(t *testing.T) {
 
 func TestWriteFailure_HandlerError(t *testing.T) {
 	h := baseHTTPHandler{
-		logger: slog.Default(),
+		logger:           slog.Default(),
+		failureConverter: defaultFailureConverter,
 	}
 
 	writer := httptest.NewRecorder()
@@ -45,14 +47,12 @@ func TestWriteFailure_HandlerError(t *testing.T) {
 
 func TestWriteFailure_UnsuccessfulOperationError(t *testing.T) {
 	h := baseHTTPHandler{
-		logger: slog.Default(),
+		logger:           slog.Default(),
+		failureConverter: defaultFailureConverter,
 	}
 
 	writer := httptest.NewRecorder()
-	h.writeFailure(writer, &UnsuccessfulOperationError{
-		State:   OperationStateCanceled,
-		Failure: Failure{Message: "canceled"},
-	})
+	h.writeFailure(writer, NewCanceledOperationError(fmt.Errorf("canceled")))
 
 	require.Equal(t, statusOperationFailed, writer.Code)
 	require.Equal(t, contentTypeJSON, writer.Header().Get("Content-Type"))

--- a/nexus/setup_test.go
+++ b/nexus/setup_test.go
@@ -15,21 +15,23 @@ const testTimeout = time.Second * 5
 const testService = "Ser/vic e"
 const getResultMaxTimeout = time.Millisecond * 300
 
-func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx context.Context, client *HTTPClient, teardown func()) {
+func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureConverter FailureConverter) (ctx context.Context, client *HTTPClient, teardown func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 
 	httpHandler := NewHTTPHandler(HandlerOptions{
 		GetResultTimeout: getResultMaxTimeout,
 		Handler:          handler,
 		Serializer:       serializer,
+		FailureConverter: failureConverter,
 	})
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	client, err = NewHTTPClient(HTTPClientOptions{
-		BaseURL:    fmt.Sprintf("http://%s/", listener.Addr().String()),
-		Service:    testService,
-		Serializer: serializer,
+		BaseURL:          fmt.Sprintf("http://%s/", listener.Addr().String()),
+		Service:          testService,
+		Serializer:       serializer,
+		FailureConverter: failureConverter,
 	})
 	require.NoError(t, err)
 
@@ -45,15 +47,16 @@ func setupSerializer(t *testing.T, handler Handler, serializer Serializer) (ctx 
 }
 
 func setup(t *testing.T, handler Handler) (ctx context.Context, client *HTTPClient, teardown func()) {
-	return setupSerializer(t, handler, nil)
+	return setupCustom(t, handler, nil, nil)
 }
 
-func setupForCompletion(t *testing.T, handler CompletionHandler, serializer Serializer) (ctx context.Context, callbackURL string, teardown func()) {
+func setupForCompletion(t *testing.T, handler CompletionHandler, serializer Serializer, failureConverter FailureConverter) (ctx context.Context, callbackURL string, teardown func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 
 	httpHandler := NewCompletionHTTPHandler(CompletionHandlerOptions{
-		Handler:    handler,
-		Serializer: serializer,
+		Handler:          handler,
+		Serializer:       serializer,
+		FailureConverter: failureConverter,
 	})
 
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -3,6 +3,7 @@ package nexus
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -236,9 +237,7 @@ func (h *unsuccessfulHandler) StartOperation(ctx context.Context, service, opera
 	return nil, &UnsuccessfulOperationError{
 		// We're passing the desired state via request ID in this test.
 		State: OperationState(options.RequestID),
-		Failure: Failure{
-			Message: "intentional",
-		},
+		Cause: fmt.Errorf("intentional"),
 	}
 }
 

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -14,22 +14,22 @@ func (h UnimplementedHandler) mustEmbedUnimplementedHandler() {}
 
 // StartOperation implements the Handler interface.
 func (h UnimplementedHandler) StartOperation(ctx context.Context, service, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
-	return nil, &HandlerError{HandlerErrorTypeNotImplemented, &Failure{Message: "not implemented"}}
+	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // GetOperationResult implements the Handler interface.
 func (h UnimplementedHandler) GetOperationResult(ctx context.Context, service, operation, operationID string, options GetOperationResultOptions) (any, error) {
-	return nil, &HandlerError{HandlerErrorTypeNotImplemented, &Failure{Message: "not implemented"}}
+	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // GetOperationInfo implements the Handler interface.
 func (h UnimplementedHandler) GetOperationInfo(ctx context.Context, service, operation, operationID string, options GetOperationInfoOptions) (*OperationInfo, error) {
-	return nil, &HandlerError{HandlerErrorTypeNotImplemented, &Failure{Message: "not implemented"}}
+	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // CancelOperation implements the Handler interface.
 func (h UnimplementedHandler) CancelOperation(ctx context.Context, service, operation, operationID string, options CancelOperationOptions) error {
-	return &HandlerError{HandlerErrorTypeNotImplemented, &Failure{Message: "not implemented"}}
+	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // UnimplementedOperation must be embedded into any [Operation] implementation for future compatibility.


### PR DESCRIPTION
💥 BREAKING CHANGE 💥 

- Add a `FailureConverter` to convert from a `Failure` to `error` and back and remove `Failure` from the main SDK APIs.
- Changed `HandlerError` to take a `Cause error` instead of a `Failure` object.
- `HandlerError` gets an `Unwrap()` method for use with helpers in the `errors` package.
- Changed `UnsuccessfulOperationError` to take a `Cause error` instead of a `Failure` object.
- `UnsuccessfulOperationError` gets an `Unwrap()` method for use with helpers in the `errors` package.
- Added new shorthand constructors for `UnsuccessfulOperationError`: `NewFailedOperationError` and `NewCanceledOperationError`.
- Added a new `NewOperationCompletionUnsuccessful` constructor that takes an error object and options to support a failure converter.
- Rename `StartLinks` to `Links`.