### PR TITLE
Add links to HandlerStartOperationResultSync

### DIFF
--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -125,7 +125,7 @@ func (h *syncOperation[I, O]) Start(ctx context.Context, input I, options StartO
 	if err != nil {
 		return nil, err
 	}
-	return &HandlerStartOperationResultSync[O]{o}, err
+	return &HandlerStartOperationResultSync[O]{Value: o, Links: options.Links}, err
 }
 
 // A Service is a container for a group of operations.

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -25,9 +25,18 @@ type HandlerStartOperationResult[T any] interface {
 // HandlerStartOperationResultSync indicates that an operation completed successfully.
 type HandlerStartOperationResultSync[T any] struct {
 	Value T
+	Links []Link
 }
 
 func (r *HandlerStartOperationResultSync[T]) applyToHTTPResponse(writer http.ResponseWriter, handler *httpHandler) {
+	if err := addLinksToHTTPHeader(r.Links, writer.Header()); err != nil {
+		handler.logger.Error("failed to serialize links into header", "error", err)
+		// clear any previous links already written to the header
+		writer.Header().Del(headerLink)
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	handler.writeResult(writer, r.Value)
 }
 

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -24,7 +24,9 @@ type HandlerStartOperationResult[T any] interface {
 
 // HandlerStartOperationResultSync indicates that an operation completed successfully.
 type HandlerStartOperationResultSync[T any] struct {
+	// Value is the output of the operation.
 	Value T
+	// Links to be associated with the operation.
 	Links []Link
 }
 
@@ -42,8 +44,10 @@ func (r *HandlerStartOperationResultSync[T]) applyToHTTPResponse(writer http.Res
 
 // HandlerStartOperationResultAsync indicates that an operation has been accepted and will complete asynchronously.
 type HandlerStartOperationResultAsync struct {
+	// OperationID is a unique ID to identify the operation.
 	OperationID string
-	Links       []Link
+	// Links to be associated with the operation.
+	Links []Link
 }
 
 func (r *HandlerStartOperationResultAsync) applyToHTTPResponse(writer http.ResponseWriter, handler *httpHandler) {

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -47,7 +47,7 @@ func (h *successHandler) StartOperation(ctx context.Context, service, operation 
 		return nil, HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'User-Agent' header: %q", options.Header.Get("User-Agent"))
 	}
 
-	return &HandlerStartOperationResultSync[any]{body}, nil
+	return &HandlerStartOperationResultSync[any]{Value: body, Links: options.Links}, nil
 }
 
 func TestSuccess(t *testing.T) {


### PR DESCRIPTION
Adding links field to sync response to support attaching links to synchronous operations.