### PR TITLE
Rename UnsuccessfulOperationError to OperationError

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ operation := nexus.NewOperationReference[MyInput, MyOutput]("example")
 // StartOperationOptions can be used to explicitly set a request ID, headers, and callback URL.
 result, err := nexus.StartOperation(ctx, client, operation, MyInput{Field: "value"}, nexus.StartOperationOptions{})
 if err != nil {
-	var unsuccessfulOperationError *nexus.UnsuccessfulOperationError
-	if errors.As(err, &unsuccessfulOperationError) { // operation failed or canceled
-		fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Cause.Error())
+	var OperationError *nexus.OperationError
+	if errors.As(err, &OperationError) { // operation failed or canceled
+		fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", OperationError.State, OperationError.Cause.Error())
 	}
 	var handlerError *nexus.HandlerError
 	if errors.As(err, &handlerError) {
@@ -94,7 +94,7 @@ in case the operation is asynchronous.
 // Set ExecuteOperationOptions.Wait to change the wait duration.
 output, err := nexus.ExecuteOperation(ctx, client, operation, MyInput{}, nexus.ExecuteOperationOptions{})
 if err != nil {
-	// handle nexus.UnsuccessfulOperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded
+	// handle nexus.OperationError, nexus.ErrOperationStillRunning, and context.DeadlineExceeded
 }
 fmt.Printf("Operation succeeded: %v\n", output) // output is of type MyOutput
 ```
@@ -160,7 +160,7 @@ connection.
 ```go
 result, err := handle.GetResult(ctx, nexus.GetOperationResultOptions{})
 if err != nil {
-	// handle nexus.UnsuccessfulOperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded
+	// handle nexus.OperationError, nexus.ErrOperationStillRunning, and context.DeadlineExceeded
 }
 // result's type is the Handle's generic type T.
 ```
@@ -295,7 +295,7 @@ func (h *myArbitraryLengthOperation) Start(ctx context.Context, input MyInput, o
 #### Get Operation Result
 
 The `GetResult` method is used to deliver an operation's result inline. If this method does not return an error, the
-operation is considered as successfully completed. Return an `UnsuccessfulOperationError` to indicate completion or an
+operation is considered as successfully completed. Return an `OperationError` to indicate completion or an
 `ErrOperationStillRunning` error to indicate that the operation is still running.
 
 When `GetOperationResultOptions.Wait` is greater than zero, this request should be treated as a long poll. Long poll

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -154,7 +154,7 @@ type ClientStartOperationResult[T any] struct {
 //     such as getting its result.
 //
 //  3. The operation was unsuccessful. The returned result will be nil and error will be an
-//     [UnsuccessfulOperationError].
+//     [OperationError].
 //
 //  4. Any other error.
 func (c *HTTPClient) StartOperation(
@@ -287,7 +287,7 @@ func (c *HTTPClient) StartOperation(
 		}
 
 		failureErr := c.options.FailureConverter.FailureToError(failure)
-		return nil, &UnsuccessfulOperationError{
+		return nil, &OperationError{
 			State: state,
 			Cause: failureErr,
 		}

--- a/nexus/client_example_test.go
+++ b/nexus/client_example_test.go
@@ -18,9 +18,9 @@ var client *nexus.HTTPClient
 func ExampleHTTPClient_StartOperation() {
 	result, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})
 	if err != nil {
-		var unsuccessfulOperationError *nexus.UnsuccessfulOperationError
-		if errors.As(err, &unsuccessfulOperationError) { // operation failed or canceled
-			fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", unsuccessfulOperationError.State, unsuccessfulOperationError.Cause.Error())
+		var OperationError *nexus.OperationError
+		if errors.As(err, &OperationError) { // operation failed or canceled
+			fmt.Printf("Operation unsuccessful with state: %s, failure message: %s\n", OperationError.State, OperationError.Cause.Error())
 		}
 		var handlerError *nexus.HandlerError
 		if errors.As(err, &handlerError) {
@@ -43,7 +43,7 @@ func ExampleHTTPClient_StartOperation() {
 func ExampleHTTPClient_ExecuteOperation() {
 	response, err := client.ExecuteOperation(ctx, "operation name", MyStruct{Field: "value"}, nexus.ExecuteOperationOptions{})
 	if err != nil {
-		// handle nexus.UnsuccessfulOperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded
+		// handle nexus.OperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded
 	}
 	// must close the returned response body and read it until EOF to free up the underlying connection
 	var output MyStruct

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -159,7 +159,7 @@ type OperationCompletionUnsuccessfulOptions struct {
 }
 
 // NewOperationCompletionUnsuccessful constructs an [OperationCompletionUnsuccessful] from a given error.
-func NewOperationCompletionUnsuccessful(error *UnsuccessfulOperationError, options OperationCompletionUnsuccessfulOptions) (*OperationCompletionUnsuccessful, error) {
+func NewOperationCompletionUnsuccessful(error *OperationError, options OperationCompletionUnsuccessfulOptions) (*OperationCompletionUnsuccessful, error) {
 	if options.FailureConverter == nil {
 		options.FailureConverter = defaultFailureConverter
 	}

--- a/nexus/get_result_test.go
+++ b/nexus/get_result_test.go
@@ -184,13 +184,13 @@ func TestPeekResult_Success(t *testing.T) {
 }
 
 func TestPeekResult_Canceled(t *testing.T) {
-	ctx, client, teardown := setup(t, &asyncWithResultHandler{resultError: &UnsuccessfulOperationError{State: OperationStateCanceled}})
+	ctx, client, teardown := setup(t, &asyncWithResultHandler{resultError: &OperationError{State: OperationStateCanceled}})
 	defer teardown()
 
 	handle, err := client.NewHandle("foo", "a/sync")
 	require.NoError(t, err)
 	_, err = handle.GetResult(ctx, GetOperationResultOptions{})
-	var unsuccessfulOperationError *UnsuccessfulOperationError
-	require.ErrorAs(t, err, &unsuccessfulOperationError)
-	require.Equal(t, OperationStateCanceled, unsuccessfulOperationError.State)
+	var OperationError *OperationError
+	require.ErrorAs(t, err, &OperationError)
+	require.Equal(t, OperationStateCanceled, OperationError.State)
 }

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -150,7 +150,7 @@ func (h *OperationHandle[T]) sendGetOperationResultRequest(request *http.Request
 			return nil, err
 		}
 		failureErr := h.client.options.FailureConverter.FailureToError(failure)
-		return nil, &UnsuccessfulOperationError{
+		return nil, &OperationError{
 			State: state,
 			Cause: failureErr,
 		}

--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -73,12 +73,12 @@ type Operation[I, O any] interface {
 
 	// Start handles requests for starting an operation. Return [HandlerStartOperationResultSync] to respond
 	// successfully - inline, or [HandlerStartOperationResultAsync] to indicate that an asynchronous operation was
-	// started. Return an [UnsuccessfulOperationError] to indicate that an operation completed as failed or
+	// started. Return an [OperationError] to indicate that an operation completed as failed or
 	// canceled.
 	Start(context.Context, I, StartOperationOptions) (HandlerStartOperationResult[O], error)
 	// GetResult handles requests to get the result of an asynchronous operation. Return non error result to respond
 	// successfully - inline, or error with [ErrOperationStillRunning] to indicate that an asynchronous operation is
-	// still running. Return an [UnsuccessfulOperationError] to indicate that an operation completed as failed or
+	// still running. Return an [OperationError] to indicate that an operation completed as failed or
 	// canceled.
 	//
 	// When [GetOperationResultOptions.Wait] is greater than zero, this request should be treated as a long poll.

--- a/nexus/operation_test.go
+++ b/nexus/operation_test.go
@@ -106,7 +106,7 @@ func TestExecuteOperation(t *testing.T) {
 	require.Equal(t, 3, result)
 
 	_, err = ExecuteOperation(ctx, client, numberValidatorOperation, 0, ExecuteOperationOptions{})
-	var unsuccessfulError *UnsuccessfulOperationError
+	var unsuccessfulError *OperationError
 	require.ErrorAs(t, err, &unsuccessfulError)
 
 	bResult, err := ExecuteOperation(ctx, client, bytesIOOperation, []byte("hello"), ExecuteOperationOptions{})

--- a/nexus/server_test.go
+++ b/nexus/server_test.go
@@ -45,7 +45,7 @@ func TestWriteFailure_HandlerError(t *testing.T) {
 	require.Equal(t, "foo", failure.Message)
 }
 
-func TestWriteFailure_UnsuccessfulOperationError(t *testing.T) {
+func TestWriteFailure_OperationError(t *testing.T) {
 	h := baseHTTPHandler{
 		logger:           slog.Default(),
 		failureConverter: defaultFailureConverter,

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -247,7 +247,7 @@ type unsuccessfulHandler struct {
 }
 
 func (h *unsuccessfulHandler) StartOperation(ctx context.Context, service, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
-	return nil, &UnsuccessfulOperationError{
+	return nil, &OperationError{
 		// We're passing the desired state via request ID in this test.
 		State: OperationState(options.RequestID),
 		Cause: fmt.Errorf("intentional"),
@@ -261,7 +261,7 @@ func TestUnsuccessful(t *testing.T) {
 	cases := []string{"canceled", "failed"}
 	for _, c := range cases {
 		_, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{RequestID: c})
-		var unsuccessfulError *UnsuccessfulOperationError
+		var unsuccessfulError *OperationError
 		require.ErrorAs(t, err, &unsuccessfulError)
 		require.Equal(t, OperationState(c), unsuccessfulError.State)
 	}


### PR DESCRIPTION
- Kept `UnsuccessfulOperationError` as an alias of `OperationError`
- Moved `HandlerError` from `server.go` to `api.go` since it is used by both the client and the server
- Improved documentation of `HandlerErrorType` and provided recommendations of whether a client should retry each of the error types
- Added an `OperationErrorf` helper function