### PR TITLE
Idiomatic Operation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ result, err := client.StartOperation(ctx, "example", MyInput{Field: "value"}, ne
 
 #### Start an Operation and Await its Completion
 
-The HTTPClient provides the `ExecuteOperation` helper function as a shorthand for `StartOperation` and issuing a `GetResult`
-in case the operation is asynchronous.
+The HTTPClient provides the `ExecuteOperation` helper function as a shorthand for `StartOperation` and calling the
+`Result` method on the returned handler in case the operation is asynchronous.
 
 ```go
 // By default ExecuteOperation will long poll until the context deadline for the operation to complete.
@@ -135,10 +135,10 @@ Handles expose a couple of readonly attributes: `Operation` and `ID`.
 
 #### Get the Result of an Operation
 
-The `GetResult` method is used to get the result of an operation, issuing a network request to the handle's client's
+The `Result` method is used to get the result of an operation, issuing a network request to the handle's client's
 configured endpoint.
 
-By default, GetResult returns (nil, `ErrOperationStillRunning`) immediately after issuing a call if the operation has
+By default, Result returns (nil, `ErrOperationStillRunning`) immediately after issuing a call if the operation has
 not yet completed.
 
 Callers may set GetOperationResultOptions.Wait to a value greater than 0 to alter this behavior, causing the client to
@@ -153,12 +153,12 @@ context deadline to the max allowed wait period to ensure this call returns in a
 
 Custom request headers may be provided via `GetOperationResultOptions`.
 
-When a handle is created from an OperationReference, `GetResult` returns a result of the reference's output type. When a
-handle is created from a name, `GetResult` returns a `LazyValue` which must be `Consume`d to free up the underlying
+When a handle is created from an OperationReference, `Result` returns a result of the reference's output type. When a
+handle is created from a name, `Result` returns a `LazyValue` which must be `Consume`d to free up the underlying
 connection.
 
 ```go
-result, err := handle.GetResult(ctx, nexus.GetOperationResultOptions{})
+result, err := handle.Result(ctx, nexus.GetOperationResultOptions{})
 if err != nil {
 	// handle nexus.OperationError, nexus.ErrOperationStillRunning, and context.DeadlineExceeded
 }
@@ -167,13 +167,13 @@ if err != nil {
 
 #### Get Operation Information
 
-The `GetInfo` method is used to get operation information (currently only the operation's state) issuing a network
+The `Info` method is used to get operation information (currently only the operation's state) issuing a network
 request to the service handler.
 
 Custom request headers may be provided via `GetOperationInfoOptions`.
 
 ```go
-info, _ := handle.GetInfo(ctx, nexus.GetOperationInfoOptions{})
+info, _ := handle.Info(ctx, nexus.GetOperationInfoOptions{})
 ```
 
 #### Cancel an Operation
@@ -251,7 +251,7 @@ func (h *myArbitraryLengthOperation) Start(ctx context.Context, input MyInput, o
 	return &HandlerStartOperationResultAsync{OperationID: "some-meaningful-id"}, nil
 }
 
-func (h *myArbitraryLengthOperation) GetResult(ctx context.Context, id string, options nexus.GetOperationResultOptions) (MyOutput, error) {
+func (h *myArbitraryLengthOperation) Result(ctx context.Context, id string, options nexus.GetOperationResultOptions) (MyOutput, error) {
 	return MyOutput{}, nil
 }
 
@@ -260,7 +260,7 @@ func (h *myArbitraryLengthOperation) Cancel(ctx context.Context, id string, opti
 	return nil
 }
 
-func (h *myArbitraryLengthOperation) GetInfo(ctx context.Context, id string, options nexus.GetOperationInfoOptions) (*nexus.OperationInfo, error) {
+func (h *myArbitraryLengthOperation) Info(ctx context.Context, id string, options nexus.GetOperationInfoOptions) (*nexus.OperationInfo, error) {
 	return &nexus.OperationInfo{ID: id, State: nexus.OperationStateRunning}, nil
 }
 ```
@@ -294,7 +294,7 @@ func (h *myArbitraryLengthOperation) Start(ctx context.Context, input MyInput, o
 
 #### Get Operation Result
 
-The `GetResult` method is used to deliver an operation's result inline. If this method does not return an error, the
+The `Result` method is used to deliver an operation's result inline. If this method does not return an error, the
 operation is considered as successfully completed. Return an `OperationError` to indicate completion or an
 `ErrOperationStillRunning` error to indicate that the operation is still running.
 
@@ -307,7 +307,7 @@ Consider using a derived context that enforces the wait timeout when implementin
 `ErrOperationStillRunning` when that context expires as shown in the example.
 
 ```go
-func (h *myArbitraryLengthOperation) GetResult(ctx context.Context, id string, options nexus.GetOperationResultOptions) (MyOutput, error) {
+func (h *myArbitraryLengthOperation) Result(ctx context.Context, id string, options nexus.GetOperationResultOptions) (MyOutput, error) {
 	if options.Wait > 0 { // request is a long poll
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, options.Wait)

--- a/nexus/client.go
+++ b/nexus/client.go
@@ -362,7 +362,7 @@ func (c *HTTPClient) ExecuteOperation(ctx context.Context, operation string, inp
 	} else {
 		gro.Wait = options.Wait
 	}
-	return handle.GetResult(ctx, gro)
+	return handle.Result(ctx, gro)
 }
 
 // NewHandle gets a handle to an asynchronous operation by name and ID.

--- a/nexus/get_info_test.go
+++ b/nexus/get_info_test.go
@@ -49,7 +49,7 @@ func TestGetHandlerFromStartInfoHeader(t *testing.T) {
 	require.NoError(t, err)
 	handle := result.Pending
 	require.NotNil(t, handle)
-	info, err := handle.GetInfo(ctx, GetOperationInfoOptions{
+	info, err := handle.Info(ctx, GetOperationInfoOptions{
 		Header: Header{"test": "ok"},
 	})
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestGetInfoHandleFromClientNoHeader(t *testing.T) {
 
 	handle, err := client.NewHandle("escape/me", "needs /URL/ escaping")
 	require.NoError(t, err)
-	info, err := handle.GetInfo(ctx, GetOperationInfoOptions{})
+	info, err := handle.Info(ctx, GetOperationInfoOptions{})
 	require.NoError(t, err)
 	require.Equal(t, handle.ID, info.ID)
 	require.Equal(t, OperationStateCanceled, info.State)
@@ -105,7 +105,7 @@ func TestGetInfo_ContextDeadlinePropagated(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "timeout")
 	require.NoError(t, err)
-	_, err = handle.GetInfo(ctx, GetOperationInfoOptions{})
+	_, err = handle.Info(ctx, GetOperationInfoOptions{})
 	require.NoError(t, err)
 }
 
@@ -117,7 +117,7 @@ func TestGetInfo_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "timeout")
 	require.NoError(t, err)
-	_, err = handle.GetInfo(ctx, GetOperationInfoOptions{Header: Header{HeaderRequestTimeout: formatDuration(timeout)}})
+	_, err = handle.Info(ctx, GetOperationInfoOptions{Header: Header{HeaderRequestTimeout: formatDuration(timeout)}})
 	require.NoError(t, err)
 }
 
@@ -127,6 +127,6 @@ func TestGetInfo_TimeoutNotPropagated(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "timeout")
 	require.NoError(t, err)
-	_, err = handle.GetInfo(context.Background(), GetOperationInfoOptions{})
+	_, err = handle.Info(context.Background(), GetOperationInfoOptions{})
 	require.NoError(t, err)
 }

--- a/nexus/get_result_test.go
+++ b/nexus/get_result_test.go
@@ -114,7 +114,7 @@ func TestWaitResult_StillRunning(t *testing.T) {
 	require.NotNil(t, handle)
 
 	ctx = context.Background()
-	_, err = handle.GetResult(ctx, GetOperationResultOptions{Wait: time.Millisecond * 200})
+	_, err = handle.Result(ctx, GetOperationResultOptions{Wait: time.Millisecond * 200})
 	require.ErrorIs(t, err, ErrOperationStillRunning)
 }
 
@@ -131,7 +131,7 @@ func TestWaitResult_DeadlineExceeded(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 	defer cancel()
 	deadline, _ := ctx.Deadline()
-	_, err = handle.GetResult(ctx, GetOperationResultOptions{Wait: time.Second})
+	_, err = handle.Result(ctx, GetOperationResultOptions{Wait: time.Second})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	// Allow up to 10 ms delay to account for slow CI.
 	// This test is inherently flaky, and should be rewritten.
@@ -150,7 +150,7 @@ func TestWaitResult_RequestTimeout(t *testing.T) {
 
 	timeout := 200 * time.Millisecond
 	deadline := time.Now().Add(timeout)
-	_, err = handle.GetResult(ctx, GetOperationResultOptions{Wait: time.Second, Header: Header{HeaderRequestTimeout: formatDuration(timeout)}})
+	_, err = handle.Result(ctx, GetOperationResultOptions{Wait: time.Second, Header: Header{HeaderRequestTimeout: formatDuration(timeout)}})
 	require.ErrorIs(t, err, ErrOperationStillRunning)
 	require.WithinDuration(t, deadline, handler.requests[0].deadline, 1*time.Millisecond)
 }
@@ -162,7 +162,7 @@ func TestPeekResult_StillRunning(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "a/sync")
 	require.NoError(t, err)
-	response, err := handle.GetResult(ctx, GetOperationResultOptions{})
+	response, err := handle.Result(ctx, GetOperationResultOptions{})
 	require.ErrorIs(t, err, ErrOperationStillRunning)
 	require.Nil(t, response)
 	require.Equal(t, 1, len(handler.requests))
@@ -175,7 +175,7 @@ func TestPeekResult_Success(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "a/sync")
 	require.NoError(t, err)
-	response, err := handle.GetResult(ctx, GetOperationResultOptions{})
+	response, err := handle.Result(ctx, GetOperationResultOptions{})
 	require.NoError(t, err)
 	var body []byte
 	err = response.Consume(&body)
@@ -189,7 +189,7 @@ func TestPeekResult_Canceled(t *testing.T) {
 
 	handle, err := client.NewHandle("foo", "a/sync")
 	require.NoError(t, err)
-	_, err = handle.GetResult(ctx, GetOperationResultOptions{})
+	_, err = handle.Result(ctx, GetOperationResultOptions{})
 	var OperationError *OperationError
 	require.ErrorAs(t, err, &OperationError)
 	require.Equal(t, OperationStateCanceled, OperationError.State)

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -19,8 +19,8 @@ type OperationHandle[T any] struct {
 	client *HTTPClient
 }
 
-// GetInfo gets operation information, issuing a network request to the service handler.
-func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationInfoOptions) (*OperationInfo, error) {
+// Info gets operation information, issuing a network request to the service handler.
+func (h *OperationHandle[T]) Info(ctx context.Context, options GetOperationInfoOptions) (*OperationInfo, error) {
 	url := h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID))
 	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
 	if err != nil {
@@ -48,9 +48,9 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 	return operationInfoFromResponse(response, body)
 }
 
-// GetResult gets the result of an operation, issuing a network request to the service handler.
+// Result gets the result of an operation, issuing a network request to the service handler.
 //
-// By default, GetResult returns (nil, [ErrOperationStillRunning]) immediately after issuing a call if the operation has
+// By default, Result returns (nil, [ErrOperationStillRunning]) immediately after issuing a call if the operation has
 // not yet completed.
 //
 // Callers may set GetOperationResultOptions.Wait to a value greater than 0 to alter this behavior, causing the client
@@ -64,7 +64,7 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 // context deadline to the max allowed wait period to ensure this call returns in a timely fashion.
 //
 // ⚠️ If a [LazyValue] is returned (as indicated by T), it must be consumed to free up the underlying connection.
-func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperationResultOptions) (T, error) {
+func (h *OperationHandle[T]) Result(ctx context.Context, options GetOperationResultOptions) (T, error) {
 	var result T
 	url := h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID), "result")
 	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)

--- a/nexus/serializer_test.go
+++ b/nexus/serializer_test.go
@@ -152,7 +152,7 @@ func TestCustomSerializer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, result)
 
-	// Async triggers GetResult, test this too.
+	// Async triggers Result, test this too.
 	result, err = ExecuteOperation(ctx, client, asyncNumberValidatorOperationInstance, 3, ExecuteOperationOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 3, result)
@@ -227,7 +227,7 @@ func TestCustomFailureConverter(t *testing.T) {
 	_, err = ExecuteOperation(ctx, client, numberValidatorOperation, 0, ExecuteOperationOptions{})
 	require.ErrorIs(t, err, errCustom)
 
-	// Async triggers GetResult, test this too.
+	// Async triggers Result, test this too.
 	_, err = ExecuteOperation(ctx, client, asyncNumberValidatorOperationInstance, 0, ExecuteOperationOptions{})
 	require.ErrorIs(t, err, errCustom)
 }

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -56,13 +56,13 @@ func (*UnimplementedOperation[I, O]) Cancel(context.Context, string, CancelOpera
 	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetInfo implements Operation.
-func (*UnimplementedOperation[I, O]) GetInfo(context.Context, string, GetOperationInfoOptions) (*OperationInfo, error) {
+// Info implements Operation.
+func (*UnimplementedOperation[I, O]) Info(context.Context, string, GetOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetResult implements Operation.
-func (*UnimplementedOperation[I, O]) GetResult(context.Context, string, GetOperationResultOptions) (O, error) {
+// Result implements Operation.
+func (*UnimplementedOperation[I, O]) Result(context.Context, string, GetOperationResultOptions) (O, error) {
 	var empty O
 	return empty, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }


### PR DESCRIPTION
💥 BREAKING CHANGE 💥 

- Change the `Operation` interface and `OperationHandle` struct `GetResult` and `GetInfo` methods to `Result` and `Info` , which are more idiomatic for Go.
- Add a `MustRegister` method on `Service` for convenience.

This breaking change should have minimal impact for Temporal use cases since these two methods were never implemented in that context.