### PR TITLE
Add support for operation token and deprecate operation ID

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -29,7 +29,13 @@ const (
 	headerRetryable          = "nexus-request-retryable"
 	// HeaderOperationID is the unique ID returned by the StartOperation response for async operations.
 	// Must be set on callback headers to support completing operations before the start response is received.
+	//
+	// Deprecated: Use HeaderOperationToken instead.
 	HeaderOperationID = "nexus-operation-id"
+
+	// HeaderOperationToken is the unique token returned by the StartOperation response for async operations.
+	// Must be set on callback headers to support completing operations before the start response is received.
+	HeaderOperationToken = "nexus-operation-token"
 
 	// HeaderRequestTimeout is the total time to complete a Nexus HTTP request.
 	HeaderRequestTimeout = "request-timeout"
@@ -184,13 +190,13 @@ const (
 	// The caller does not have permission to execute the specified operation. Clients should not retry this
 	// request unless advised otherwise.
 	HandlerErrorTypeUnauthorized HandlerErrorType = "UNAUTHORIZED"
-	// The requested resource could not be found but may be available in the future. Subsequent requests by the
-	// client are permissible but not advised.
+	// The requested resource could not be found but may be available in the future. Clients should not retry this
+	// request unless advised otherwise.
 	HandlerErrorTypeNotFound HandlerErrorType = "NOT_FOUND"
 	// Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of
 	// space. Subsequent requests by the client are permissible.
 	HandlerErrorTypeResourceExhausted HandlerErrorType = "RESOURCE_EXHAUSTED"
-	// An internal error occured. Clients should not retry this request unless advised otherwise.
+	// An internal error occured. Subsequent requests by the client are permissible.
 	HandlerErrorTypeInternal HandlerErrorType = "INTERNAL"
 	// The server either does not recognize the request method, or it lacks the ability to fulfill the request.
 	// Clients should not retry this request unless advised otherwise.
@@ -287,7 +293,11 @@ var ErrOperationStillRunning = errors.New("operation still running")
 // OperationInfo conveys information about an operation.
 type OperationInfo struct {
 	// ID of the operation.
+	//
+	// Deprecated: Use Token instead.
 	ID string `json:"id"`
+	// Token for the operation.
+	Token string `json:"token"`
 	// State of the operation.
 	State OperationState `json:"state"`
 }

--- a/nexus/cancel_test.go
+++ b/nexus/cancel_test.go
@@ -15,19 +15,19 @@ type asyncWithCancelHandler struct {
 
 func (h *asyncWithCancelHandler) StartOperation(ctx context.Context, service, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
 	return &HandlerStartOperationResultAsync{
-		OperationID: "a/sync",
+		OperationToken: "a/sync",
 	}, nil
 }
 
-func (h *asyncWithCancelHandler) CancelOperation(ctx context.Context, service, operation, operationID string, options CancelOperationOptions) error {
+func (h *asyncWithCancelHandler) CancelOperation(ctx context.Context, service, operation, token string, options CancelOperationOptions) error {
 	if service != testService {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "unexpected service: %s", service)
 	}
 	if operation != "f/o/o" {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected operation to be 'foo', got: %s", operation)
 	}
-	if operationID != "a/sync" {
-		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected operation ID to be 'async', got: %s", operationID)
+	if token != "a/sync" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected operation ID to be 'async', got: %s", token)
 	}
 	if h.expectHeader && options.Header.Get("foo") != "bar" {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'foo' request header")
@@ -69,11 +69,11 @@ type echoTimeoutAsyncWithCancelHandler struct {
 
 func (h *echoTimeoutAsyncWithCancelHandler) StartOperation(ctx context.Context, service, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
 	return &HandlerStartOperationResultAsync{
-		OperationID: "timeout",
+		OperationToken: "timeout",
 	}, nil
 }
 
-func (h *echoTimeoutAsyncWithCancelHandler) CancelOperation(ctx context.Context, service, operation, operationID string, options CancelOperationOptions) error {
+func (h *echoTimeoutAsyncWithCancelHandler) CancelOperation(ctx context.Context, service, operation, token string, options CancelOperationOptions) error {
 	deadline, set := ctx.Deadline()
 	if h.expectedTimeout > 0 && !set {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected operation to have timeout set but context has no deadline")

--- a/nexus/completion.go
+++ b/nexus/completion.go
@@ -13,6 +13,8 @@ import (
 )
 
 // NewCompletionHTTPRequest creates an HTTP request deliver an operation completion to a given URL.
+//
+// NOTE: Experimental
 func NewCompletionHTTPRequest(ctx context.Context, url string, completion OperationCompletion) (*http.Request, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, nil)
 	if err != nil {
@@ -28,11 +30,15 @@ func NewCompletionHTTPRequest(ctx context.Context, url string, completion Operat
 
 // OperationCompletion is input for [NewCompletionHTTPRequest].
 // It has two implementations: [OperationCompletionSuccessful] and [OperationCompletionUnsuccessful].
+//
+// NOTE: Experimental
 type OperationCompletion interface {
 	applyToHTTPRequest(*http.Request) error
 }
 
 // OperationCompletionSuccessful is input for [NewCompletionHTTPRequest], used to deliver successful operation results.
+//
+// NOTE: Experimental
 type OperationCompletionSuccessful struct {
 	// Header to send in the completion request.
 	// Note that this is a Nexus header, not an HTTP header.
@@ -43,7 +49,12 @@ type OperationCompletionSuccessful struct {
 	// Automatically closed when the completion is delivered.
 	Reader *Reader
 	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	//
+	// Deprecated: Use OperatonToken instead.
 	OperationID string
+	// OperationToken is the unique token for this operation. Used when a completion callback is received before a
+	// started response.
+	OperationToken string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
 	// Links are used to link back to the operation when a completion callback is received before a started response.
@@ -51,12 +62,19 @@ type OperationCompletionSuccessful struct {
 }
 
 // OperationCompletionSuccessfulOptions are options for [NewOperationCompletionSuccessful].
+//
+// NOTE: Experimental
 type OperationCompletionSuccessfulOptions struct {
 	// Optional serializer for the result. Defaults to the SDK's default Serializer, which handles JSONables, byte
 	// slices and nils.
 	Serializer Serializer
 	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	//
+	// Deprecated: Use OperatonToken instead.
 	OperationID string
+	// OperationToken is the unique token for this operation. Used when a completion callback is received before a
+	// started response.
+	OperationToken string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
 	// Links are used to link back to the operation when a completion callback is received before a started response.
@@ -64,6 +82,8 @@ type OperationCompletionSuccessfulOptions struct {
 }
 
 // NewOperationCompletionSuccessful constructs an [OperationCompletionSuccessful] from a given result.
+//
+// NOTE: Experimental
 func NewOperationCompletionSuccessful(result any, options OperationCompletionSuccessfulOptions) (*OperationCompletionSuccessful, error) {
 	reader, ok := result.(*Reader)
 	if !ok {
@@ -92,11 +112,12 @@ func NewOperationCompletionSuccessful(result any, options OperationCompletionSuc
 	}
 
 	return &OperationCompletionSuccessful{
-		Header:      make(Header),
-		Reader:      reader,
-		OperationID: options.OperationID,
-		StartTime:   options.StartTime,
-		Links:       options.Links,
+		Header:         make(Header),
+		Reader:         reader,
+		OperationID:    options.OperationID,
+		OperationToken: options.OperationToken,
+		StartTime:      options.StartTime,
+		Links:          options.Links,
 	}, nil
 }
 
@@ -111,8 +132,17 @@ func (c *OperationCompletionSuccessful) applyToHTTPRequest(request *http.Request
 		addNexusHeaderToHTTPHeader(c.Header, request.Header)
 	}
 	request.Header.Set(headerOperationState, string(OperationStateSucceeded))
+
+	if c.OperationID == "" && c.OperationToken != "" {
+		c.OperationID = c.OperationToken
+	} else if c.OperationToken == "" && c.OperationID != "" {
+		c.OperationToken = c.OperationID
+	}
 	if c.Header.Get(HeaderOperationID) == "" && c.OperationID != "" {
 		request.Header.Set(HeaderOperationID, c.OperationID)
+	}
+	if c.Header.Get(HeaderOperationToken) == "" && c.OperationToken != "" {
+		request.Header.Set(HeaderOperationToken, c.OperationToken)
 	}
 	if c.Header.Get(headerOperationStartTime) == "" && !c.StartTime.IsZero() {
 		request.Header.Set(headerOperationStartTime, c.StartTime.Format(http.TimeFormat))
@@ -129,6 +159,8 @@ func (c *OperationCompletionSuccessful) applyToHTTPRequest(request *http.Request
 
 // OperationCompletionUnsuccessful is input for [NewCompletionHTTPRequest], used to deliver unsuccessful operation
 // results.
+//
+// NOTE: Experimental
 type OperationCompletionUnsuccessful struct {
 	// Header to send in the completion request.
 	// Note that this is a Nexus header, not an HTTP header.
@@ -136,7 +168,12 @@ type OperationCompletionUnsuccessful struct {
 	// State of the operation, should be failed or canceled.
 	State OperationState
 	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	//
+	// Deprecated: Use OperatonToken instead.
 	OperationID string
+	// OperationToken is the unique token for this operation. Used when a completion callback is received before a
+	// started response.
+	OperationToken string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
 	// Links are used to link back to the operation when a completion callback is received before a started response.
@@ -146,12 +183,19 @@ type OperationCompletionUnsuccessful struct {
 }
 
 // OperationCompletionUnsuccessfulOptions are options for [NewOperationCompletionUnsuccessful].
+//
+// NOTE: Experimental
 type OperationCompletionUnsuccessfulOptions struct {
 	// A [FailureConverter] to convert a [Failure] instance to and from an [error]. Defaults to
 	// [DefaultFailureConverter].
 	FailureConverter FailureConverter
 	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	//
+	// Deprecated: Use OperatonToken instead.
 	OperationID string
+	// OperationToken is the unique token for this operation. Used when a completion callback is received before a
+	// started response.
+	OperationToken string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
 	// Links are used to link back to the operation when a completion callback is received before a started response.
@@ -159,18 +203,21 @@ type OperationCompletionUnsuccessfulOptions struct {
 }
 
 // NewOperationCompletionUnsuccessful constructs an [OperationCompletionUnsuccessful] from a given error.
+//
+// NOTE: Experimental
 func NewOperationCompletionUnsuccessful(error *OperationError, options OperationCompletionUnsuccessfulOptions) (*OperationCompletionUnsuccessful, error) {
 	if options.FailureConverter == nil {
 		options.FailureConverter = defaultFailureConverter
 	}
 
 	return &OperationCompletionUnsuccessful{
-		Header:      make(Header),
-		State:       error.State,
-		Failure:     options.FailureConverter.ErrorToFailure(error.Cause),
-		OperationID: options.OperationID,
-		StartTime:   options.StartTime,
-		Links:       options.Links,
+		Header:         make(Header),
+		State:          error.State,
+		Failure:        options.FailureConverter.ErrorToFailure(error.Cause),
+		OperationID:    options.OperationID,
+		OperationToken: options.OperationToken,
+		StartTime:      options.StartTime,
+		Links:          options.Links,
 	}, nil
 }
 
@@ -183,8 +230,17 @@ func (c *OperationCompletionUnsuccessful) applyToHTTPRequest(request *http.Reque
 	}
 	request.Header.Set(headerOperationState, string(c.State))
 	request.Header.Set("Content-Type", contentTypeJSON)
+
+	if c.OperationID == "" && c.OperationToken != "" {
+		c.OperationID = c.OperationToken
+	}
+	if c.OperationToken == "" && c.OperationID != "" {
+		c.OperationToken = c.OperationID
+	}
 	if c.Header.Get(HeaderOperationID) == "" && c.OperationID != "" {
 		request.Header.Set(HeaderOperationID, c.OperationID)
+	} else if c.Header.Get(HeaderOperationToken) == "" && c.OperationToken != "" {
+		request.Header.Set(HeaderOperationToken, c.OperationToken)
 	}
 	if c.Header.Get(headerOperationStartTime) == "" && !c.StartTime.IsZero() {
 		request.Header.Set(headerOperationStartTime, c.StartTime.Format(http.TimeFormat))
@@ -205,13 +261,20 @@ func (c *OperationCompletionUnsuccessful) applyToHTTPRequest(request *http.Reque
 }
 
 // CompletionRequest is input for CompletionHandler.CompleteOperation.
+//
+// NOTE: Experimental
 type CompletionRequest struct {
 	// The original HTTP request.
 	HTTPRequest *http.Request
 	// State of the operation.
 	State OperationState
-	// OperationID is the ID of the operation. Used when a completion callback is received before a started response.
+	// OperationID is the unique ID for this operation. Used when a completion callback is received before a started response.
+	//
+	// Deprecated: Use OperatonToken instead.
 	OperationID string
+	// OperationToken is the unique token for this operation. Used when a completion callback is received before a
+	// started response.
+	OperationToken string
 	// StartTime is the time the operation started. Used when a completion callback is received before a started response.
 	StartTime time.Time
 	// Links are used to link back to the operation when a completion callback is received before a started response.
@@ -224,11 +287,15 @@ type CompletionRequest struct {
 
 // A CompletionHandler can receive operation completion requests as delivered via the callback URL provided in
 // start-operation requests.
+//
+// NOTE: Experimental
 type CompletionHandler interface {
 	CompleteOperation(context.Context, *CompletionRequest) error
 }
 
 // CompletionHandlerOptions are options for [NewCompletionHTTPHandler].
+//
+// NOTE: Experimental
 type CompletionHandlerOptions struct {
 	// Handler for completion requests.
 	Handler CompletionHandler
@@ -251,9 +318,15 @@ type completionHTTPHandler struct {
 func (h *completionHTTPHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 	completion := CompletionRequest{
-		State:       OperationState(request.Header.Get(headerOperationState)),
-		OperationID: request.Header.Get(HeaderOperationID),
-		HTTPRequest: request,
+		State:          OperationState(request.Header.Get(headerOperationState)),
+		OperationID:    request.Header.Get(HeaderOperationID),
+		OperationToken: request.Header.Get(HeaderOperationToken),
+		HTTPRequest:    request,
+	}
+	if completion.OperationID == "" && completion.OperationToken != "" {
+		completion.OperationID = completion.OperationToken
+	} else if completion.OperationToken == "" && completion.OperationID != "" {
+		completion.OperationToken = completion.OperationID
 	}
 	if startTimeHeader := request.Header.Get(headerOperationStartTime); startTimeHeader != "" {
 		var parseTimeErr error
@@ -302,6 +375,8 @@ func (h *completionHTTPHandler) ServeHTTP(writer http.ResponseWriter, request *h
 }
 
 // NewCompletionHTTPHandler constructs an [http.Handler] from given options for handling operation completion requests.
+//
+// NOTE: Experimental
 func NewCompletionHTTPHandler(options CompletionHandlerOptions) http.Handler {
 	if options.Logger == nil {
 		options.Logger = slog.Default()

--- a/nexus/completion_test.go
+++ b/nexus/completion_test.go
@@ -28,8 +28,11 @@ func (h *successfulCompletionHandler) CompleteOperation(ctx context.Context, com
 	if completion.HTTPRequest.Header.Get("User-Agent") != userAgent {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'User-Agent' header: %q", completion.HTTPRequest.Header.Get("User-Agent"))
 	}
-	if completion.OperationID != "test-operation-id" {
-		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid %q header: %q", HeaderOperationID, completion.HTTPRequest.Header.Get(HeaderOperationID))
+	if completion.OperationID != "test-operation-token" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid operation ID: %q", completion.OperationID)
+	}
+	if completion.OperationToken != "test-operation-token" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid operation token: %q", completion.OperationToken)
 	}
 	if len(completion.Links) == 0 {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected Links to be set on CompletionRequest")
@@ -50,8 +53,8 @@ func TestSuccessfulCompletion(t *testing.T) {
 	defer teardown()
 
 	completion, err := NewOperationCompletionSuccessful(666, OperationCompletionSuccessfulOptions{
-		OperationID: "test-operation-id",
-		StartTime:   time.Now(),
+		OperationToken: "test-operation-token",
+		StartTime:      time.Now(),
 		Links: []Link{{
 			URL: &url.URL{
 				Scheme:   "https",
@@ -93,7 +96,7 @@ func TestSuccessfulCompletion_CustomSerializer(t *testing.T) {
 		}},
 	})
 	completion.Header.Set("foo", "bar")
-	completion.Header.Set(HeaderOperationID, "test-operation-id")
+	completion.Header.Set(HeaderOperationToken, "test-operation-token")
 	require.NoError(t, err)
 
 	request, err := NewCompletionHTTPRequest(ctx, callbackURL, completion)
@@ -123,8 +126,11 @@ func (h *failureExpectingCompletionHandler) CompleteOperation(ctx context.Contex
 	if completion.HTTPRequest.Header.Get("foo") != "bar" {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid 'foo' header: %q", completion.HTTPRequest.Header.Get("foo"))
 	}
-	if completion.OperationID != "test-operation-id" {
-		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid %q header: %q", HeaderOperationID, completion.HTTPRequest.Header.Get(HeaderOperationID))
+	if completion.OperationID != "test-operation-token" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid operation ID: %q", completion.OperationID)
+	}
+	if completion.OperationToken != "test-operation-token" {
+		return HandlerErrorf(HandlerErrorTypeBadRequest, "invalid operation token: %q", completion.OperationToken)
 	}
 	if len(completion.Links) == 0 {
 		return HandlerErrorf(HandlerErrorTypeBadRequest, "expected Links to be set on CompletionRequest")
@@ -145,8 +151,8 @@ func TestFailureCompletion(t *testing.T) {
 	defer teardown()
 
 	completion, err := NewOperationCompletionUnsuccessful(NewCanceledOperationError(errors.New("expected message")), OperationCompletionUnsuccessfulOptions{
-		OperationID: "test-operation-id",
-		StartTime:   time.Now(),
+		OperationToken: "test-operation-token",
+		StartTime:      time.Now(),
 		Links: []Link{{
 			URL: &url.URL{
 				Scheme:   "https",
@@ -183,7 +189,7 @@ func TestFailureCompletion_CustomFailureConverter(t *testing.T) {
 
 	completion, err := NewOperationCompletionUnsuccessful(NewCanceledOperationError(errors.New("expected message")), OperationCompletionUnsuccessfulOptions{
 		FailureConverter: fc,
-		OperationID:      "test-operation-id",
+		OperationToken:   "test-operation-token",
 		StartTime:        time.Now(),
 		Links: []Link{{
 			URL: &url.URL{

--- a/nexus/get_result_test.go
+++ b/nexus/get_result_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 type request struct {
-	options     GetOperationResultOptions
-	operation   string
-	operationID string
-	deadline    time.Time
+	options   GetOperationResultOptions
+	operation string
+	token     string
+	deadline  time.Time
 }
 
 type asyncWithResultHandler struct {
@@ -29,7 +29,7 @@ func (h *asyncWithResultHandler) StartOperation(ctx context.Context, service, op
 	}
 
 	return &HandlerStartOperationResultAsync{
-		OperationID: "a/sync",
+		OperationToken: "async",
 	}, nil
 }
 
@@ -40,8 +40,8 @@ func (h *asyncWithResultHandler) getResult() (any, error) {
 	return []byte("body"), nil
 }
 
-func (h *asyncWithResultHandler) GetOperationResult(ctx context.Context, service, operation, operationID string, options GetOperationResultOptions) (any, error) {
-	req := request{options: options, operation: operation, operationID: operationID}
+func (h *asyncWithResultHandler) GetOperationResult(ctx context.Context, service, operation, token string, options GetOperationResultOptions) (any, error) {
+	req := request{options: options, operation: operation, token: token}
 	deadline, set := ctx.Deadline()
 	if set {
 		req.deadline = deadline
@@ -101,7 +101,7 @@ func TestWaitResult(t *testing.T) {
 	require.InDelta(t, testTimeout+getResultContextPadding, handler.requests[0].options.Wait, float64(time.Millisecond*50))
 	require.InDelta(t, testTimeout+getResultContextPadding-getResultMaxTimeout, handler.requests[1].options.Wait, float64(time.Millisecond*50))
 	require.Equal(t, "f/o/o", handler.requests[0].operation)
-	require.Equal(t, "a/sync", handler.requests[0].operationID)
+	require.Equal(t, "async", handler.requests[0].token)
 }
 
 func TestWaitResult_StillRunning(t *testing.T) {

--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -15,16 +15,29 @@ type OperationHandle[T any] struct {
 	// Name of the Operation this handle represents.
 	Operation string
 	// Handler generated ID for this handle's operation.
-	ID     string
+	//
+	// Deprecated: Use Token instead.
+	ID string
+	// Handler generated token for this handle's operation.
+	Token string
+
 	client *HTTPClient
 }
 
 // GetInfo gets operation information, issuing a network request to the service handler.
 func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationInfoOptions) (*OperationInfo, error) {
-	url := h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID))
-	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	var u *url.URL
+	if h.client.options.UseOperationID {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID))
+	} else {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation))
+	}
+	request, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+	if !h.client.options.UseOperationID {
+		request.Header.Set(HeaderOperationToken, h.Token)
 	}
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	addNexusHeaderToHTTPHeader(options.Header, request.Header)
@@ -66,10 +79,18 @@ func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationIn
 // ⚠️ If a [LazyValue] is returned (as indicated by T), it must be consumed to free up the underlying connection.
 func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperationResultOptions) (T, error) {
 	var result T
-	url := h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID), "result")
-	request, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	var u *url.URL
+	if h.client.options.UseOperationID {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID), "result")
+	} else {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), "result")
+	}
+	request, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return result, err
+	}
+	if !h.client.options.UseOperationID {
+		request.Header.Set(HeaderOperationToken, h.Token)
 	}
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
@@ -163,11 +184,21 @@ func (h *OperationHandle[T]) sendGetOperationResultRequest(request *http.Request
 //
 // Cancelation is asynchronous and may be not be respected by the operation's implementation.
 func (h *OperationHandle[T]) Cancel(ctx context.Context, options CancelOperationOptions) error {
-	url := h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID), "cancel")
-	request, err := http.NewRequestWithContext(ctx, "POST", url.String(), nil)
+	var u *url.URL
+	if h.client.options.UseOperationID {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), url.PathEscape(h.ID), "cancel")
+	} else {
+		u = h.client.serviceBaseURL.JoinPath(url.PathEscape(h.client.options.Service), url.PathEscape(h.Operation), "cancel")
+	}
+	request, err := http.NewRequestWithContext(ctx, "POST", u.String(), nil)
 	if err != nil {
 		return err
 	}
+
+	if !h.client.options.UseOperationID {
+		request.Header.Set(HeaderOperationToken, h.Token)
+	}
+
 	addContextTimeoutToHTTPHeader(ctx, request.Header)
 	request.Header.Set(headerUserAgent, userAgent)
 	addNexusHeaderToHTTPHeader(options.Header, request.Header)

--- a/nexus/handle_test.go
+++ b/nexus/handle_test.go
@@ -9,11 +9,11 @@ import (
 func TestNewHandleFailureConditions(t *testing.T) {
 	client, err := NewHTTPClient(HTTPClientOptions{BaseURL: "http://foo.com", Service: "test"})
 	require.NoError(t, err)
-	_, err = client.NewHandle("", "id")
+	_, err = client.NewHandle("", "token")
 	require.ErrorIs(t, err, errEmptyOperationName)
 	_, err = client.NewHandle("name", "")
-	require.ErrorIs(t, err, errEmptyOperationID)
+	require.ErrorIs(t, err, errEmptyOperationToken)
 	_, err = client.NewHandle("", "")
 	require.ErrorIs(t, err, errEmptyOperationName)
-	require.ErrorIs(t, err, errEmptyOperationID)
+	require.ErrorIs(t, err, errEmptyOperationToken)
 }

--- a/nexus/handler_example_test.go
+++ b/nexus/handler_example_test.go
@@ -22,11 +22,11 @@ func (h *myHandler) StartOperation(ctx context.Context, service, operation strin
 	if err := h.authorize(ctx, options.Header); err != nil {
 		return nil, err
 	}
-	return &nexus.HandlerStartOperationResultAsync{OperationID: "meaningful-id"}, nil
+	return &nexus.HandlerStartOperationResultAsync{OperationToken: "some-token"}, nil
 }
 
 // GetOperationResult implements the Handler interface.
-func (h *myHandler) GetOperationResult(ctx context.Context, service, operation, operationID string, options nexus.GetOperationResultOptions) (any, error) {
+func (h *myHandler) GetOperationResult(ctx context.Context, service, operation, token string, options nexus.GetOperationResultOptions) (any, error) {
 	if err := h.authorize(ctx, options.Header); err != nil {
 		return nil, err
 	}
@@ -59,12 +59,12 @@ func (h *myHandler) GetOperationResult(ctx context.Context, service, operation, 
 	}
 }
 
-func (h *myHandler) CancelOperation(ctx context.Context, service, operation, operationID string, options nexus.CancelOperationOptions) error {
+func (h *myHandler) CancelOperation(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
 	// Handlers must implement this.
 	panic("unimplemented")
 }
 
-func (h *myHandler) GetOperationInfo(ctx context.Context, service, operation, operationID string, options nexus.GetOperationInfoOptions) (*nexus.OperationInfo, error) {
+func (h *myHandler) GetOperationInfo(ctx context.Context, service, operation, token string, options nexus.GetOperationInfoOptions) (*nexus.OperationInfo, error) {
 	// Handlers must implement this.
 	panic("unimplemented")
 }

--- a/nexus/operation_test.go
+++ b/nexus/operation_test.go
@@ -37,25 +37,25 @@ func (h *asyncNumberValidatorOperation) Start(ctx context.Context, input int, op
 	return &HandlerStartOperationResultAsync{OperationID: fmt.Sprintf("%d", input)}, nil
 }
 
-func (h *asyncNumberValidatorOperation) GetResult(ctx context.Context, id string, options GetOperationResultOptions) (int, error) {
-	if id == "0" {
+func (h *asyncNumberValidatorOperation) GetResult(ctx context.Context, token string, options GetOperationResultOptions) (int, error) {
+	if token == "0" {
 		return 0, NewFailedOperationError(fmt.Errorf("cannot process 0"))
 	}
-	return strconv.Atoi(id)
+	return strconv.Atoi(token)
 }
 
-func (h *asyncNumberValidatorOperation) Cancel(ctx context.Context, id string, options CancelOperationOptions) error {
+func (h *asyncNumberValidatorOperation) Cancel(ctx context.Context, token string, options CancelOperationOptions) error {
 	if options.Header.Get("fail") != "" {
 		return fmt.Errorf("intentionally failed")
 	}
 	return nil
 }
 
-func (h *asyncNumberValidatorOperation) GetInfo(ctx context.Context, id string, options GetOperationInfoOptions) (*OperationInfo, error) {
+func (h *asyncNumberValidatorOperation) GetInfo(ctx context.Context, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
 	if options.Header.Get("fail") != "" {
 		return nil, fmt.Errorf("intentionally failed")
 	}
-	return &OperationInfo{ID: id, State: OperationStateRunning}, nil
+	return &OperationInfo{Token: token, State: OperationStateRunning}, nil
 }
 
 var asyncNumberValidatorOperationInstance = &asyncNumberValidatorOperation{}
@@ -142,7 +142,7 @@ func TestStartOperation(t *testing.T) {
 	value, err := result.Pending.GetResult(ctx, GetOperationResultOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 3, value)
-	handle, err := NewHandle(client, asyncNumberValidatorOperationInstance, result.Pending.ID)
+	handle, err := NewHandle(client, asyncNumberValidatorOperationInstance, result.Pending.Token)
 	require.NoError(t, err)
 	value, err = handle.GetResult(ctx, GetOperationResultOptions{})
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestGetOperationInfo(t *testing.T) {
 	require.NoError(t, err)
 	info, err := result.Pending.GetInfo(ctx, GetOperationInfoOptions{})
 	require.NoError(t, err)
-	require.Equal(t, &OperationInfo{ID: "3", State: OperationStateRunning}, info)
+	require.Equal(t, &OperationInfo{Token: "3", ID: "3", State: OperationStateRunning}, info)
 	_, err = result.Pending.GetInfo(ctx, GetOperationInfoOptions{Header: Header{"fail": "1"}})
 	var handlerError *HandlerError
 	require.ErrorAs(t, err, &handlerError)
@@ -210,15 +210,15 @@ func (h *authRejectionHandler) Start(ctx context.Context, input NoValue, options
 	return nil, HandlerErrorf(HandlerErrorTypeUnauthorized, "unauthorized in test")
 }
 
-func (h *authRejectionHandler) GetResult(ctx context.Context, id string, options GetOperationResultOptions) (NoValue, error) {
+func (h *authRejectionHandler) GetResult(ctx context.Context, token string, options GetOperationResultOptions) (NoValue, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeUnauthorized, "unauthorized in test")
 }
 
-func (h *authRejectionHandler) Cancel(ctx context.Context, id string, options CancelOperationOptions) error {
+func (h *authRejectionHandler) Cancel(ctx context.Context, token string, options CancelOperationOptions) error {
 	return HandlerErrorf(HandlerErrorTypeUnauthorized, "unauthorized in test")
 }
 
-func (h *authRejectionHandler) GetInfo(ctx context.Context, id string, options GetOperationInfoOptions) (*OperationInfo, error) {
+func (h *authRejectionHandler) GetInfo(ctx context.Context, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeUnauthorized, "unauthorized in test")
 }
 

--- a/nexus/server.go
+++ b/nexus/server.go
@@ -445,7 +445,12 @@ func (h *httpHandler) handleRequest(writer http.ResponseWriter, request *http.Re
 		h.writeFailure(writer, HandlerErrorf(HandlerErrorTypeBadRequest, "failed to parse URL path"))
 		return
 	}
-	if token := request.Header.Get(HeaderOperationToken); token != "" {
+	token := request.Header.Get(HeaderOperationToken)
+	if token == "" {
+		token = request.URL.Query().Get("token")
+	}
+
+	if token != "" {
 		switch len(parts) {
 		case 3: // /{service}/{operation}
 			if request.Method != "GET" {
@@ -474,8 +479,6 @@ func (h *httpHandler) handleRequest(writer http.ResponseWriter, request *http.Re
 			h.writeFailure(writer, HandlerErrorf(HandlerErrorTypeNotFound, "not found"))
 		}
 	} else {
-		var token string
-
 		if len(parts) > 3 {
 			token, err = url.PathUnescape(parts[3])
 			if err != nil {

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -252,7 +252,7 @@ type asyncHandler struct {
 
 func (h *asyncHandler) StartOperation(ctx context.Context, service, operation string, input *LazyValue, options StartOperationOptions) (HandlerStartOperationResult[any], error) {
 	return &HandlerStartOperationResultAsync{
-		OperationID: "async",
+		OperationToken: "async",
 	}, nil
 }
 

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -18,17 +18,17 @@ func (h UnimplementedHandler) StartOperation(ctx context.Context, service, opera
 }
 
 // GetOperationResult implements the Handler interface.
-func (h UnimplementedHandler) GetOperationResult(ctx context.Context, service, operation, operationID string, options GetOperationResultOptions) (any, error) {
+func (h UnimplementedHandler) GetOperationResult(ctx context.Context, service, operation, token string, options GetOperationResultOptions) (any, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // GetOperationInfo implements the Handler interface.
-func (h UnimplementedHandler) GetOperationInfo(ctx context.Context, service, operation, operationID string, options GetOperationInfoOptions) (*OperationInfo, error) {
+func (h UnimplementedHandler) GetOperationInfo(ctx context.Context, service, operation, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // CancelOperation implements the Handler interface.
-func (h UnimplementedHandler) CancelOperation(ctx context.Context, service, operation, operationID string, options CancelOperationOptions) error {
+func (h UnimplementedHandler) CancelOperation(ctx context.Context, service, operation, token string, options CancelOperationOptions) error {
 	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
@@ -52,17 +52,17 @@ func (*UnimplementedOperation[I, O]) OutputType() reflect.Type {
 }
 
 // Cancel implements Operation.
-func (*UnimplementedOperation[I, O]) Cancel(context.Context, string, CancelOperationOptions) error {
+func (*UnimplementedOperation[I, O]) Cancel(ctx context.Context, token string, options CancelOperationOptions) error {
 	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // GetInfo implements Operation.
-func (*UnimplementedOperation[I, O]) GetInfo(context.Context, string, GetOperationInfoOptions) (*OperationInfo, error) {
+func (*UnimplementedOperation[I, O]) GetInfo(ctx context.Context, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
 // GetResult implements Operation.
-func (*UnimplementedOperation[I, O]) GetResult(context.Context, string, GetOperationResultOptions) (O, error) {
+func (*UnimplementedOperation[I, O]) GetResult(ctx context.Context, token string, options GetOperationResultOptions) (O, error) {
 	var empty O
 	return empty, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }


### PR DESCRIPTION
- Also fix docstring for handler error types
- Also mark all exported functions and structs in completion.go as experimental - those need to be redone to properly rehydrate errors

See also https://github.com/nexus-rpc/api/pull/16