### PR TITLE
Rename service client and add UnimplementedTransport

### DIFF
--- a/nexus/handle_test.go
+++ b/nexus/handle_test.go
@@ -10,7 +10,7 @@ func TestNewHandleFailureConditions(t *testing.T) {
 	tr, err := NewHTTPTransport(HTTPTransportOptions{BaseURL: "http://foo.com"})
 	require.NoError(t, err)
 
-	client, err := NewClient(ClientOptions{Service: "test", Transport: tr})
+	client, err := NewServiceClient(ServiceClientOptions{Service: "test", Transport: tr})
 	require.NoError(t, err)
 	_, err = client.NewOperationHandle("", "token")
 	require.ErrorIs(t, err, errEmptyOperationName)

--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -394,13 +394,13 @@ func (r *rootOperationHandler) Start(ctx context.Context, input any, options Sta
 	return ret.(HandlerStartOperationResult[any]), nil
 }
 
-// ExecuteOperation is the type safe version of [Client.ExecuteOperation].
+// ExecuteOperation is the type safe version of [ServiceClient.ExecuteOperation].
 // It accepts input of type I and returns output of type O, removing the need to consume the [LazyValue] returned by the
 // client method.
 //
 //	ref := NewOperationReference[MyInput, MyOutput]("my-operation")
 //	out, err := ExecuteOperation(ctx, client, ref, MyInput{}, options) // returns MyOutput, error
-func ExecuteOperation[I, O any](ctx context.Context, client *Client, operation OperationReference[I, O], input I, request ExecuteOperationOptions) (O, error) {
+func ExecuteOperation[I, O any](ctx context.Context, client *ServiceClient, operation OperationReference[I, O], input I, request ExecuteOperationOptions) (O, error) {
 	var o O
 	value, err := client.ExecuteOperation(ctx, operation.Name(), input, request)
 	if err != nil {
@@ -409,10 +409,10 @@ func ExecuteOperation[I, O any](ctx context.Context, client *Client, operation O
 	return o, value.Consume(&o)
 }
 
-// StartOperation is the type safe version of [Client.StartOperation].
+// StartOperation is the type safe version of [ServiceClient.StartOperation].
 // It accepts input of type I and returns a [ClientStartOperationResponse] of type O, removing the need to consume the
 // [LazyValue] returned by the client method.
-func StartOperation[I, O any](ctx context.Context, client *Client, operation OperationReference[I, O], input I, request StartOperationOptions) (*ClientStartOperationResponse[O], error) {
+func StartOperation[I, O any](ctx context.Context, client *ServiceClient, operation OperationReference[I, O], input I, request StartOperationOptions) (*ClientStartOperationResponse[O], error) {
 	resp, err := client.StartOperation(ctx, operation.Name(), input, request)
 	if err != nil {
 		return nil, err
@@ -449,9 +449,9 @@ func StartOperation[I, O any](ctx context.Context, client *Client, operation Ope
 	}, nil
 }
 
-// NewOperationHandle is the type safe version of [Client.NewOperationHandle].
+// NewOperationHandle is the type safe version of [ServiceClient.NewOperationHandle].
 // The [OperationHandle.GetResult] method will return an output of type O.
-func NewOperationHandle[I, O any](client *Client, operation OperationReference[I, O], token string) (*OperationHandle[O], error) {
+func NewOperationHandle[I, O any](client *ServiceClient, operation OperationReference[I, O], token string) (*OperationHandle[O], error) {
 	if token == "" {
 		return nil, errEmptyOperationToken
 	}

--- a/nexus/options.go
+++ b/nexus/options.go
@@ -35,7 +35,7 @@ type StartOperationOptions struct {
 //
 // NOTE: Experimental
 type TransportStartOperationOptions struct {
-	// Options passed to [Client.StartOperation].
+	// Options passed to [ServiceClient.StartOperation].
 	ClientOptions StartOperationOptions
 	// Service name. Required.
 	Service string
@@ -43,12 +43,12 @@ type TransportStartOperationOptions struct {
 	Operation string
 }
 
-// ExecuteOperationOptions are options for [Client.ExecuteOperation].
+// ExecuteOperationOptions are options for [ServiceClient.ExecuteOperation].
 //
 // NOTE: Experimental
 type ExecuteOperationOptions struct {
 	// Callback URL to provide to the handle for receiving async operation completions. Optional.
-	// Even though Client.ExecuteOperation waits for operation completion, some applications may want to set this
+	// Even though ServiceClient.ExecuteOperation waits for operation completion, some applications may want to set this
 	// callback as a fallback mechanism.
 	CallbackURL string
 	// Optional header fields set by a client that are required to be attached to the callback request when an

--- a/nexus/serializer.go
+++ b/nexus/serializer.go
@@ -80,14 +80,14 @@ type Serializer interface {
 
 // FailureConverter is used by the framework to transform [error] instances to and from [Failure] instances.
 // To customize conversion logic, implement this interface and provide your implementation to framework methods such as
-// [NewClient] and [NewHTTPHandler].
+// [NewServiceClient] and [NewHTTPHandler].
 // By default the SDK translates only error messages, losing type information and struct fields.
 type FailureConverter interface {
 	// ErrorToFailure converts an [error] to a [Failure].
 	// Implementors should take a best-effort approach and never fail this method.
 	// Note that the provided error may be nil.
 	ErrorToFailure(error) Failure
-	// ErrorToFailure converts a [Failure] to an [error].
+	// FailureToError converts a [Failure] to an [error].
 	// Implementors should take a best-effort approach and never fail this method.
 	FailureToError(Failure) error
 }

--- a/nexus/service_client_example_test.go
+++ b/nexus/service_client_example_test.go
@@ -13,7 +13,7 @@ type MyStruct struct {
 }
 
 var ctx = context.Background()
-var client *nexus.Client
+var client *nexus.ServiceClient
 
 func ExampleClient_StartOperation() {
 	response, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})
@@ -22,7 +22,7 @@ func ExampleClient_StartOperation() {
 		if errors.As(err, &handlerError) {
 			fmt.Printf("Handler returned an error, type: %s, failure message: %s\n", handlerError.Type, handlerError.Cause.Error())
 		}
-		// most other errors should be returned as *nexus.UnexpectedResponseError
+		// most other errors should be returned as *nexus.TransportError
 	}
 	if response.Complete != nil { // operation complete
 		result, opErr := response.Complete.Get()

--- a/nexus/service_client_test.go
+++ b/nexus/service_client_test.go
@@ -12,12 +12,12 @@ func TestNewHTTPClient(t *testing.T) {
 	transport, err := NewHTTPTransport(HTTPTransportOptions{BaseURL: "http://example.com"})
 	require.NoError(t, err)
 
-	_, err = NewClient(ClientOptions{Service: "", Transport: transport})
+	_, err = NewServiceClient(ServiceClientOptions{Service: "", Transport: transport})
 	require.ErrorContains(t, err, "empty Service")
 
-	_, err = NewClient(ClientOptions{Service: "valid", Transport: nil})
+	_, err = NewServiceClient(ServiceClientOptions{Service: "valid", Transport: nil})
 	require.ErrorContains(t, err, "nil Transport")
 
-	_, err = NewClient(ClientOptions{Service: "valid", Transport: transport})
+	_, err = NewServiceClient(ServiceClientOptions{Service: "valid", Transport: transport})
 	require.NoError(t, err)
 }

--- a/nexus/setup_test.go
+++ b/nexus/setup_test.go
@@ -15,7 +15,7 @@ const testTimeout = time.Second * 5
 const testService = "Ser/vic e"
 const getResultMaxTimeout = time.Millisecond * 300
 
-func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureConverter FailureConverter) (ctx context.Context, client *Client, teardown func()) {
+func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureConverter FailureConverter) (ctx context.Context, client *ServiceClient, teardown func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 
 	httpHandler := NewHTTPHandler(HandlerOptions{
@@ -33,7 +33,7 @@ func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureCo
 		FailureConverter: failureConverter,
 	})
 	require.NoError(t, err)
-	client, err = NewClient(ClientOptions{Service: testService, Transport: transport})
+	client, err = NewServiceClient(ServiceClientOptions{Service: testService, Transport: transport})
 	require.NoError(t, err)
 
 	go func() {
@@ -47,7 +47,7 @@ func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureCo
 	}
 }
 
-func setup(t *testing.T, handler Handler) (ctx context.Context, client *Client, teardown func()) {
+func setup(t *testing.T, handler Handler) (ctx context.Context, client *ServiceClient, teardown func()) {
 	return setupCustom(t, handler, nil, nil)
 }
 


### PR DESCRIPTION
* Renamed `client.go` -> `service_client.go` and `Client` -> `ServiceClient`
* Renamed `UnexpectedResponseError` -> `TransportError` and moved to `transport.go`
* Added `UnimplementedTransport` and `mustEmbedUnimplementedTransport` to the `Transport` interface for future compatibility