### PR TITLE
Add StartOperation response variants

### DIFF
--- a/nexus/cancel_test.go
+++ b/nexus/cancel_test.go
@@ -44,7 +44,7 @@ func TestCancel_HandleFromStart(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "f/o/o", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	handle := result.Pending
+	handle := result.Async()
 	require.NotNil(t, handle)
 	err = handle.Cancel(ctx, CancelOperationOptions{
 		Header: Header{"foo": "bar"},

--- a/nexus/get_info_test.go
+++ b/nexus/get_info_test.go
@@ -47,7 +47,7 @@ func TestGetHandlerFromStartInfoHeader(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "escape/me", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	handle := result.Pending
+	handle := result.Async()
 	require.NotNil(t, handle)
 	info, err := handle.GetInfo(ctx, GetOperationInfoOptions{
 		Header: Header{"test": "ok"},

--- a/nexus/get_result_test.go
+++ b/nexus/get_result_test.go
@@ -110,7 +110,7 @@ func TestWaitResult_StillRunning(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	handle := result.Pending
+	handle := result.Async()
 	require.NotNil(t, handle)
 
 	ctx = context.Background()
@@ -125,7 +125,7 @@ func TestWaitResult_DeadlineExceeded(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	handle := result.Pending
+	handle := result.Async()
 	require.NotNil(t, handle)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
@@ -145,7 +145,7 @@ func TestWaitResult_RequestTimeout(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	handle := result.Pending
+	handle := result.Async()
 	require.NotNil(t, handle)
 
 	timeout := 200 * time.Millisecond

--- a/nexus/service_client_example_test.go
+++ b/nexus/service_client_example_test.go
@@ -15,7 +15,7 @@ type MyStruct struct {
 var ctx = context.Background()
 var client *nexus.ServiceClient
 
-func ExampleClient_StartOperation() {
+func ExampleServiceClient_StartOperation() {
 	response, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})
 	if err != nil {
 		var handlerError *nexus.HandlerError
@@ -24,8 +24,8 @@ func ExampleClient_StartOperation() {
 		}
 		// most other errors should be returned as *nexus.TransportError
 	}
-	if response.Complete != nil { // operation complete
-		result, opErr := response.Complete.Get()
+	if response.Sync() != nil { // operation complete
+		result, opErr := response.Sync().Get()
 		if opErr != nil {
 			var operationErr *nexus.OperationError
 			if errors.As(err, &operationErr) { // operation failed or canceled
@@ -40,12 +40,12 @@ func ExampleClient_StartOperation() {
 			fmt.Printf("Got response: %v\n", output)
 		}
 	} else { // operation started asynchronously
-		handle := response.Pending
+		handle := response.Async()
 		fmt.Printf("Started asynchronous operation with token: %s\n", handle.Token)
 	}
 }
 
-func ExampleClient_ExecuteOperation() {
+func ExampleServiceClient_ExecuteOperation() {
 	response, err := client.ExecuteOperation(ctx, "operation name", MyStruct{Field: "value"}, nexus.ExecuteOperationOptions{})
 	if err != nil {
 		// handle nexus.OperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded

--- a/nexus/start_test.go
+++ b/nexus/start_test.go
@@ -134,7 +134,7 @@ func TestClientRequestID(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			response, err := client.StartOperation(ctx, "foo", nil, c.request)
 			require.NoError(t, err)
-			result, err := response.Complete.Get()
+			result, err := response.Sync().Get()
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			var responseBody []byte
@@ -163,7 +163,7 @@ func TestJSON(t *testing.T) {
 
 	response, err := client.StartOperation(ctx, "foo", "success", StartOperationOptions{})
 	require.NoError(t, err)
-	result, err := response.Complete.Get()
+	result, err := response.Sync().Get()
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	var operationResult string
@@ -238,7 +238,7 @@ func TestReaderIO(t *testing.T) {
 			response, err := client.StartOperation(ctx, "foo", tc.input, StartOperationOptions{Header: tc.header, Links: tc.links})
 			require.NoError(t, err)
 			require.Equal(t, tc.links, response.Links)
-			result, err := response.Complete.Get()
+			result, err := response.Sync().Get()
 			require.NoError(t, err)
 			require.NotNil(t, response)
 			var operationResult string
@@ -265,7 +265,7 @@ func TestAsync(t *testing.T) {
 
 	result, err := client.StartOperation(ctx, "foo", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	require.NotNil(t, result.Pending)
+	require.NotNil(t, result.Async())
 }
 
 type unsuccessfulHandler struct {
@@ -334,7 +334,7 @@ func TestStart_RequestTimeoutHeaderOverridesContextDeadline(t *testing.T) {
 }
 
 func requireTimeoutPropagated(t *testing.T, response *ClientStartOperationResponse[*LazyValue], expected time.Duration) {
-	result, err := response.Complete.Get()
+	result, err := response.Sync().Get()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	var responseBody []byte
@@ -352,7 +352,7 @@ func TestStart_TimeoutNotPropagated(t *testing.T) {
 
 	response, err := client.StartOperation(context.Background(), "foo", nil, StartOperationOptions{})
 	require.NoError(t, err)
-	result, err := response.Complete.Get()
+	result, err := response.Sync().Get()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	var responseBody []byte
@@ -367,7 +367,7 @@ func TestStart_NilContentHeaderDoesNotPanic(t *testing.T) {
 
 	response, err := client.StartOperation(context.Background(), "op", &Content{Data: []byte("abc")}, StartOperationOptions{})
 	require.NoError(t, err)
-	result, err := response.Complete.Get()
+	result, err := response.Sync().Get()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	var responseBody []byte


### PR DESCRIPTION
Changed the format of `TransportStartOperationResponse` and `ClientStartOperationResponse` to contain a single `Variant` instead of multiple nil-able fields.

This allows for more flexibility when adding additional response types in the future and makes it easier for callers to use type assertions to determine the outcome of their StartOperation call.

For users that do not want to expand the types, `Sync()` and `Async()` (the only two current response variants) have been added so users can directly get the value, or nil if that response variant was not set.

The approach is essentially lifted from the way protobuf handles oneof variants.