### PR TITLE
Rename Get to Fetch in all APIs and structs

### DIFF
--- a/nexus/handle.go
+++ b/nexus/handle.go
@@ -21,47 +21,47 @@ type OperationHandle[T any] struct {
 	transport Transport
 }
 
-// GetInfo gets operation information, issuing a network request to the service handler.
+// FetchInfo gets operation information, issuing a network request to the service handler.
 //
 // NOTE: Experimental
-func (h *OperationHandle[T]) GetInfo(ctx context.Context, options GetOperationInfoOptions) (*OperationInfo, error) {
-	to := TransportGetOperationInfoOptions{
+func (h *OperationHandle[T]) FetchInfo(ctx context.Context, options FetchOperationInfoOptions) (*OperationInfo, error) {
+	to := TransportFetchOperationInfoOptions{
 		ClientOptions: options,
 		Service:       h.Service,
 		Operation:     h.Operation,
 		Token:         h.Token,
 	}
-	resp, err := h.transport.GetOperationInfo(ctx, to)
+	resp, err := h.transport.FetchOperationInfo(ctx, to)
 	if err != nil {
 		return nil, err
 	}
 	return resp.Info, nil
 }
 
-// GetResult gets the result of an operation, issuing a network request to the service handler.
+// FetchResult gets the result of an operation, issuing a network request to the service handler.
 //
-// This is a convenience method on top of GetResultWithDetails for callers who do not wish to inspect metadata.
+// This is a convenience method on top of FetchResultWithDetails for callers who do not wish to inspect metadata.
 //
 // The returned error may be an [OperationError] returned by the handler, indicating the operation completed
 // unsuccessfully, a [HandlerError] indicating a failure to communicate with the handler, or any other error.
 //
 // NOTE: Experimental
-func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperationResultOptions) (T, error) {
+func (h *OperationHandle[T]) FetchResult(ctx context.Context, options FetchOperationResultOptions) (T, error) {
 	var result T
-	res, err := h.GetResultWithDetails(ctx, options)
+	res, err := h.FetchResultWithDetails(ctx, options)
 	if err != nil {
 		return result, err
 	}
 	return res.Get()
 }
 
-// GetResultWithDetails gets the result of an operation and associated metadata, issuing a network request to the service
+// FetchResultWithDetails gets the result of an operation and associated metadata, issuing a network request to the service
 // handler.
 //
-// By default, GetOperationResult returns (nil, [ErrOperationStillRunning]) immediately after issuing a call if the
+// By default, FetchOperationResult returns (nil, [ErrOperationStillRunning]) immediately after issuing a call if the
 // operation has not yet completed.
 //
-// Callers may set GetOperationResultOptions.Wait to a value greater than 0 to alter this behavior, causing the client
+// Callers may set FetchOperationResultOptions.Wait to a value greater than 0 to alter this behavior, causing the client
 // to long poll for the result issuing one or more requests until the provided wait period exceeds, in which case (nil,
 // [ErrOperationStillRunning]) is returned.
 //
@@ -79,18 +79,18 @@ func (h *OperationHandle[T]) GetResult(ctx context.Context, options GetOperation
 // ⚠️ If a [LazyValue] is returned (as indicated by T), it must be consumed to free up the underlying connection.
 //
 // NOTE: Experimental
-func (h *OperationHandle[T]) GetResultWithDetails(ctx context.Context, options GetOperationResultOptions) (*OperationHandleResultWithDetails[T], error) {
-	to := TransportGetOperationResultOptions{
+func (h *OperationHandle[T]) FetchResultWithDetails(ctx context.Context, options FetchOperationResultOptions) (*OperationHandleResultWithDetails[T], error) {
+	to := TransportFetchOperationResultOptions{
 		ClientOptions: options,
 		Service:       h.Service,
 		Operation:     h.Operation,
 		Token:         h.Token,
 	}
-	resp, err := h.transport.GetOperationResult(ctx, to)
+	resp, err := h.transport.FetchOperationResult(ctx, to)
 	if err != nil {
 		return nil, err
 	}
-	lv, err := resp.GetResult()
+	lv, err := resp.Result()
 	if err != nil {
 		return &OperationHandleResultWithDetails[T]{
 			result: &OperationResult[T]{

--- a/nexus/handler_example_test.go
+++ b/nexus/handler_example_test.go
@@ -25,8 +25,8 @@ func (h *myHandler) StartOperation(ctx context.Context, service, operation strin
 	return &nexus.HandlerStartOperationResultAsync{OperationToken: "some-token"}, nil
 }
 
-// GetOperationResult implements the Handler interface.
-func (h *myHandler) GetOperationResult(ctx context.Context, service, operation, token string, options nexus.GetOperationResultOptions) (any, error) {
+// FetchOperationResult implements the Handler interface.
+func (h *myHandler) FetchOperationResult(ctx context.Context, service, operation, token string, options nexus.FetchOperationResultOptions) (any, error) {
 	if err := h.authorize(ctx, options.Header); err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (h *myHandler) CancelOperation(ctx context.Context, service, operation, tok
 	panic("unimplemented")
 }
 
-func (h *myHandler) GetOperationInfo(ctx context.Context, service, operation, token string, options nexus.GetOperationInfoOptions) (*nexus.OperationInfo, error) {
+func (h *myHandler) FetchOperationInfo(ctx context.Context, service, operation, token string, options nexus.FetchOperationInfoOptions) (*nexus.OperationInfo, error) {
 	// Handlers must implement this.
 	panic("unimplemented")
 }

--- a/nexus/options.go
+++ b/nexus/options.go
@@ -69,14 +69,14 @@ type ExecuteOperationOptions struct {
 	Header Header
 	// Duration to wait for operation completion.
 	//
-	// ⚠ NOTE: unlike GetOperationResultOptions.Wait, zero and negative values are considered effectively infinite.
+	// ⚠ NOTE: unlike FetchOperationResultOptions.Wait, zero and negative values are considered effectively infinite.
 	Wait time.Duration
 }
 
-// GetOperationResultOptions are options for the GetOperationResult client and server APIs.
+// FetchOperationResultOptions are options for the FetchOperationResult client and server APIs.
 //
 // NOTE: Experimental
-type GetOperationResultOptions struct {
+type FetchOperationResultOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
@@ -88,12 +88,12 @@ type GetOperationResultOptions struct {
 	Wait time.Duration
 }
 
-// TransportGetOperationResultOptions are options for [Transport.GetOperationResult].
+// TransportFetchOperationResultOptions are options for [Transport.FetchOperationResult].
 //
 // NOTE: Experimental
-type TransportGetOperationResultOptions struct {
-	// Options passed to [OperationHandle.GetResult].
-	ClientOptions GetOperationResultOptions
+type TransportFetchOperationResultOptions struct {
+	// Options passed to [OperationHandle.FetchResult].
+	ClientOptions FetchOperationResultOptions
 	// Service name. Required.
 	Service string
 	// Operation name. Required.
@@ -102,10 +102,10 @@ type TransportGetOperationResultOptions struct {
 	Token string
 }
 
-// GetOperationInfoOptions are options for the GetOperationInfo client and server APIs.
+// FetchOperationInfoOptions are options for the FetchOperationInfo client and server APIs.
 //
 // NOTE: Experimental
-type GetOperationInfoOptions struct {
+type FetchOperationInfoOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.
@@ -114,12 +114,12 @@ type GetOperationInfoOptions struct {
 	Header Header
 }
 
-// TransportGetOperationInfoOptions are options for [Transport.GetOperationInfo].
+// TransportFetchOperationInfoOptions are options for [Transport.FetchOperationInfo].
 //
 // NOTE: Experimental
-type TransportGetOperationInfoOptions struct {
-	// Options passed to [OperationHandle.GetInfo].
-	ClientOptions GetOperationInfoOptions
+type TransportFetchOperationInfoOptions struct {
+	// Options passed to [OperationHandle.FetchInfo].
+	ClientOptions FetchOperationInfoOptions
 	// Service name. Required.
 	Service string
 	// Operation name. Required.

--- a/nexus/serializer_test.go
+++ b/nexus/serializer_test.go
@@ -152,7 +152,7 @@ func TestCustomSerializer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, result)
 
-	// Async triggers GetResult, test this too.
+	// Async triggers FetchResult, test this too.
 	result, err = ExecuteOperation(ctx, client, asyncNumberValidatorOperationInstance, 3, ExecuteOperationOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 3, result)
@@ -227,7 +227,7 @@ func TestCustomFailureConverter(t *testing.T) {
 	_, err = ExecuteOperation(ctx, client, numberValidatorOperation, 0, ExecuteOperationOptions{})
 	require.ErrorIs(t, err, errCustom)
 
-	// Async triggers GetResult, test this too.
+	// Async triggers FetchResult, test this too.
 	_, err = ExecuteOperation(ctx, client, asyncNumberValidatorOperationInstance, 0, ExecuteOperationOptions{})
 	require.ErrorIs(t, err, errCustom)
 }

--- a/nexus/service_client.go
+++ b/nexus/service_client.go
@@ -142,7 +142,7 @@ func (c *ServiceClient) ExecuteOperation(
 		return result.Complete.Get()
 	}
 	handle := result.Pending
-	gro := GetOperationResultOptions{
+	gro := FetchOperationResultOptions{
 		Header: options.Header,
 	}
 	if options.Wait <= 0 {
@@ -150,7 +150,7 @@ func (c *ServiceClient) ExecuteOperation(
 	} else {
 		gro.Wait = options.Wait
 	}
-	return handle.GetResult(ctx, gro)
+	return handle.FetchResult(ctx, gro)
 }
 
 // NewOperationHandle gets a handle to an asynchronous operation by name and token.

--- a/nexus/service_client_example_test.go
+++ b/nexus/service_client_example_test.go
@@ -15,7 +15,7 @@ type MyStruct struct {
 var ctx = context.Background()
 var client *nexus.ServiceClient
 
-func ExampleClient_StartOperation() {
+func ExampleServiceClient_StartOperation() {
 	response, err := client.StartOperation(ctx, "example", MyStruct{Field: "value"}, nexus.StartOperationOptions{})
 	if err != nil {
 		var handlerError *nexus.HandlerError
@@ -45,7 +45,7 @@ func ExampleClient_StartOperation() {
 	}
 }
 
-func ExampleClient_ExecuteOperation() {
+func ExampleServiceClient_ExecuteOperation() {
 	response, err := client.ExecuteOperation(ctx, "operation name", MyStruct{Field: "value"}, nexus.ExecuteOperationOptions{})
 	if err != nil {
 		// handle nexus.OperationError, nexus.ErrOperationStillRunning and, context.DeadlineExceeded

--- a/nexus/setup_test.go
+++ b/nexus/setup_test.go
@@ -13,16 +13,16 @@ import (
 
 const testTimeout = time.Second * 5
 const testService = "Ser/vic e"
-const getResultMaxTimeout = time.Millisecond * 300
+const fetchResultMaxTimeout = time.Millisecond * 300
 
 func setupCustom(t *testing.T, handler Handler, serializer Serializer, failureConverter FailureConverter) (ctx context.Context, client *ServiceClient, teardown func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 
 	httpHandler := NewHTTPHandler(HandlerOptions{
-		GetResultTimeout: getResultMaxTimeout,
-		Handler:          handler,
-		Serializer:       serializer,
-		FailureConverter: failureConverter,
+		FetchResultTimeout: fetchResultMaxTimeout,
+		Handler:            handler,
+		Serializer:         serializer,
+		FailureConverter:   failureConverter,
 	})
 
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -17,13 +17,13 @@ func (h UnimplementedHandler) StartOperation(ctx context.Context, service, opera
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetOperationResult implements the Handler interface.
-func (h UnimplementedHandler) GetOperationResult(ctx context.Context, service, operation, token string, options GetOperationResultOptions) (any, error) {
+// FetchOperationResult implements the Handler interface.
+func (h UnimplementedHandler) FetchOperationResult(ctx context.Context, service, operation, token string, options FetchOperationResultOptions) (any, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetOperationInfo implements the Handler interface.
-func (h UnimplementedHandler) GetOperationInfo(ctx context.Context, service, operation, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
+// FetchOperationInfo implements the Handler interface.
+func (h UnimplementedHandler) FetchOperationInfo(ctx context.Context, service, operation, token string, options FetchOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
@@ -56,13 +56,13 @@ func (*UnimplementedOperation[I, O]) Cancel(ctx context.Context, token string, o
 	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetInfo implements Operation.
-func (*UnimplementedOperation[I, O]) GetInfo(ctx context.Context, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
+// FetchInfo implements Operation.
+func (*UnimplementedOperation[I, O]) FetchInfo(ctx context.Context, token string, options FetchOperationInfoOptions) (*OperationInfo, error) {
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetResult implements Operation.
-func (*UnimplementedOperation[I, O]) GetResult(ctx context.Context, token string, options GetOperationResultOptions) (O, error) {
+// FetchResult implements Operation.
+func (*UnimplementedOperation[I, O]) FetchResult(ctx context.Context, token string, options FetchOperationResultOptions) (O, error) {
 	var empty O
 	return empty, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }


### PR DESCRIPTION
Renamed all `GetInfo` and `GetResult` related APIs and structs to `FetchInfo` and `FetchResult`

This is a breaking change that will be part of the `v1.0.0` release.