### PR TITLE
Downgrade Go to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.25"
+          go-version: "1.23"
       - name: Lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nexus-rpc/sdk-go
 
-go 1.25
+go 1.23
 
 require github.com/stretchr/testify v1.8.4
 

--- a/nexus/operation_test.go
+++ b/nexus/operation_test.go
@@ -79,7 +79,7 @@ func startOperation(
 	options StartOperationOptions,
 ) (HandlerStartOperationResult[any], error) {
 	t.Helper()
-	ctx := WithHandlerContext(t.Context(), HandlerInfo{
+	ctx := WithHandlerContext(context.Background(), HandlerInfo{
 		Service:   svc.Name,
 		Operation: op.Name(),
 		Header:    options.Header,
@@ -96,7 +96,7 @@ func cancelOperation(
 	options CancelOperationOptions,
 ) error {
 	t.Helper()
-	ctx := WithHandlerContext(t.Context(), HandlerInfo{
+	ctx := WithHandlerContext(context.Background(), HandlerInfo{
 		Service:   svc.Name,
 		Operation: op.Name(),
 		Header:    options.Header,


### PR DESCRIPTION
I didn't realize the implications of bumping it to 1.25 originally. Lowering the requirement to 1.23 to match the Temporal Go SDK.