### PR TITLE
Remove deprecated APIs

### DIFF
--- a/nexus/api.go
+++ b/nexus/api.go
@@ -13,12 +13,6 @@ import (
 )
 
 const (
-	// HeaderOperationID is the unique ID returned by the StartOperation response for async operations.
-	// Must be set on callback headers to support completing operations before the start response is received.
-	//
-	// Deprecated: Use HeaderOperationToken instead.
-	HeaderOperationID = "nexus-operation-id"
-
 	// HeaderOperationToken is the unique token returned by the StartOperation response for async operations.
 	// Must be set on callback headers to support completing operations before the start response is received.
 	HeaderOperationToken = "nexus-operation-token"
@@ -64,22 +58,6 @@ type OperationError struct {
 	Cause error
 }
 
-// UnsuccessfulOperationError represents "failed" and "canceled" operation results.
-//
-// Deprecated: Use [OperationError] instead.
-type UnsuccessfulOperationError = OperationError
-
-// NewFailedOperationError is shorthand for constructing an [OperationError] with state set to
-// [OperationStateFailed] and the given err as the cause.
-//
-// Deprecated: Use [NewOperationFailedError] or construct an [OperationError] directly instead.
-func NewFailedOperationError(err error) *OperationError {
-	return &OperationError{
-		State: OperationStateFailed,
-		Cause: err,
-	}
-}
-
 // NewOperationFailedError is shorthand for constructing an [OperationError] with state set to
 // [OperationStateFailed] and the given error message as the cause.
 func NewOperationFailedError(message string) *OperationError {
@@ -95,17 +73,6 @@ func OperationFailedErrorf(format string, args ...any) *OperationError {
 	return &OperationError{
 		State: OperationStateFailed,
 		Cause: fmt.Errorf(format, args...),
-	}
-}
-
-// NewCanceledOperationError is shorthand for constructing an [OperationError] with state set to
-// [OperationStateCanceled] and the given err as the cause.
-//
-// Deprecated: Use [NewOperationCanceledError] or construct an [OperationError] directly instead.
-func NewCanceledOperationError(err error) *OperationError {
-	return &OperationError{
-		State: OperationStateCanceled,
-		Cause: err,
 	}
 }
 
@@ -270,10 +237,6 @@ func (e *HandlerError) Unwrap() error {
 
 // OperationInfo conveys information about an operation.
 type OperationInfo struct {
-	// ID of the operation.
-	//
-	// Deprecated: Use Token instead.
-	ID string `json:"id"`
 	// Token for the operation.
 	Token string `json:"token"`
 	// State of the operation.

--- a/nexus/handler.go
+++ b/nexus/handler.go
@@ -107,10 +107,6 @@ type HandlerStartOperationResult[T any] interface {
 type HandlerStartOperationResultSync[T any] struct {
 	// Value is the output of the operation.
 	Value T
-	// Links to be associated with the operation.
-	//
-	// Deprecated: Use AddHandlerLinks instead.
-	Links []Link
 }
 
 func (*HandlerStartOperationResultSync[T]) mustImplementHandlerStartOperationResult() {}
@@ -122,16 +118,8 @@ func (r *HandlerStartOperationResultSync[T]) ValueAsAny() any {
 
 // HandlerStartOperationResultAsync indicates that an operation has been accepted and will complete asynchronously.
 type HandlerStartOperationResultAsync struct {
-	// OperationID is a unique ID to identify the operation.
-	//
-	// Deprecated: Use OperationToken instead.
-	OperationID string
 	// OperationToken is a unique token to identify the operation.
 	OperationToken string
-	// Links to be associated with the operation.
-	//
-	// Deprecated: Use AddHandlerLinks instead.
-	Links []Link
 }
 
 func (*HandlerStartOperationResultAsync) mustImplementHandlerStartOperationResult() {}
@@ -155,20 +143,5 @@ type Handler interface {
 	//  ignored by the underlying operation implemention.
 	//  2. idempotent - implementors should ignore duplicate cancelations for the same operation.
 	CancelOperation(ctx context.Context, service, operation, token string, options CancelOperationOptions) error
-	// GetOperationResult handles requests to get the result of an asynchronous operation. Return non error result
-	// to respond successfully - inline, or error with [ErrOperationStillRunning] to indicate that an asynchronous
-	// operation is still running. Return an [OperationError] to indicate that an operation completed as
-	// failed or canceled.
-	//
-	// When [GetOperationResultOptions.Wait] is greater than zero, this request should be treated as a long poll.
-	// Long poll requests have a server side timeout, configurable via [HandlerOptions.GetResultTimeout], and exposed
-	// via context deadline. The context deadline is decoupled from the application level Wait duration.
-	//
-	// Deprecated: Getting a result directly from a handler is no longer supported.
-	GetOperationResult(ctx context.Context, service, operation, token string, options GetOperationResultOptions) (any, error)
-	// GetOperationInfo handles requests to get information about an asynchronous operation.
-	//
-	// Deprecated: Getting info directly from a handler is no longer supported.
-	GetOperationInfo(ctx context.Context, service, operation, token string, options GetOperationInfoOptions) (*OperationInfo, error)
 	mustEmbedUnimplementedHandler()
 }

--- a/nexus/operation.go
+++ b/nexus/operation.go
@@ -97,15 +97,15 @@ type OperationHandler[I, O any] interface {
 type syncOperation[I, O any] struct {
 	UnimplementedOperation[I, O]
 
-	Handler func(context.Context, I, StartOperationOptions) (O, error)
+	handler func(context.Context, I, StartOperationOptions) (O, error)
 	name    string
 }
 
 // NewSyncOperation is a helper for creating a synchronous-only [Operation] from a given name and handler function.
-func NewSyncOperation[I, O any](name string, handler func(context.Context, I, StartOperationOptions) (O, error)) Operation[I, O] {
+func NewSyncOperation[I, O any](name string, handler func(ctx context.Context, input I, options StartOperationOptions) (O, error)) Operation[I, O] {
 	return &syncOperation[I, O]{
 		name:    name,
-		Handler: handler,
+		handler: handler,
 	}
 }
 
@@ -116,7 +116,7 @@ func (h *syncOperation[I, O]) Name() string {
 
 // Start implements Operation.
 func (h *syncOperation[I, O]) Start(ctx context.Context, input I, options StartOperationOptions) (HandlerStartOperationResult[O], error) {
-	o, err := h.Handler(ctx, input, options)
+	o, err := h.handler(ctx, input, options)
 	if err != nil {
 		return nil, err
 	}

--- a/nexus/options.go
+++ b/nexus/options.go
@@ -1,7 +1,5 @@
 package nexus
 
-import "time"
-
 // StartOperationOptions are options for the StartOperation client and server APIs.
 type StartOperationOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
@@ -31,33 +29,6 @@ type StartOperationOptions struct {
 
 // CancelOperationOptions are options for the CancelOperation client and server APIs.
 type CancelOperationOptions struct {
-	// Header contains the request header fields either received by the server or to be sent by the client.
-	//
-	// Header will always be non empty in server methods and can be optionally set in the client API.
-	//
-	// Header values set here will overwrite any SDK-provided values for the same key.
-	Header Header
-}
-
-// GetOperationResultOptions are options for the GetOperationResult client and server APIs.
-//
-// Deprecated: Getting a result from a handler is no longer supported.
-type GetOperationResultOptions struct {
-	// Header contains the request header fields either received by the server or to be sent by the client.
-	//
-	// Header will always be non empty in server methods and can be optionally set in the client API.
-	//
-	// Header values set here will overwrite any SDK-provided values for the same key.
-	Header Header
-	// If non-zero, reflects the duration the caller has indicated that it wants to wait for operation completion,
-	// turning the request into a long poll.
-	Wait time.Duration
-}
-
-// GetOperationInfoOptions are options for the GetOperationInfo client and server APIs.
-//
-// Deprecated: Getting info from a handler is no longer supported.
-type GetOperationInfoOptions struct {
 	// Header contains the request header fields either received by the server or to be sent by the client.
 	//
 	// Header will always be non empty in server methods and can be optionally set in the client API.

--- a/nexus/unimplemented_handler.go
+++ b/nexus/unimplemented_handler.go
@@ -17,16 +17,6 @@ func (h UnimplementedHandler) StartOperation(ctx context.Context, service, opera
 	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
 }
 
-// GetOperationResult implements the Handler interface.
-func (h UnimplementedHandler) GetOperationResult(ctx context.Context, service, operation, token string, options GetOperationResultOptions) (any, error) {
-	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
-}
-
-// GetOperationInfo implements the Handler interface.
-func (h UnimplementedHandler) GetOperationInfo(ctx context.Context, service, operation, token string, options GetOperationInfoOptions) (*OperationInfo, error) {
-	return nil, HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")
-}
-
 // CancelOperation implements the Handler interface.
 func (h UnimplementedHandler) CancelOperation(ctx context.Context, service, operation, token string, options CancelOperationOptions) error {
 	return HandlerErrorf(HandlerErrorTypeNotImplemented, "not implemented")


### PR DESCRIPTION
Waiting for a Temporal Go SDK release, which references these APIs, before merging this to avoid breaking Temporal users.