### PR TITLE
Mark some APIs experimental we aren't ready to commit to.

### DIFF
--- a/nexus/handler.go
+++ b/nexus/handler.go
@@ -131,6 +131,8 @@ func (*HandlerStartOperationResultAsync) mustImplementHandlerStartOperationResul
 // All Handler methods can return a [HandlerError] to fail requests with a custom [HandlerErrorType] and structured [Failure].
 // Arbitrary errors from handler methods are turned into [HandlerErrorTypeInternal], their details are logged and hidden
 // from the caller.
+//
+// NOTE: Experimental
 type Handler interface {
 	// StartOperation handles requests for starting an operation. Return [HandlerStartOperationResultSync] to
 	// respond successfully - inline, or [HandlerStartOperationResultAsync] to indicate that an asynchronous

--- a/nexus/serializer.go
+++ b/nexus/serializer.go
@@ -10,6 +10,8 @@ import (
 
 // A Reader is a container for a [Header] and an [io.Reader].
 // It is used to stream inputs and outputs in the various client and server APIs.
+//
+// NOTE: Experimental
 type Reader struct {
 	// ReaderCloser contains request or response data. May be nil for empty data.
 	io.ReadCloser
@@ -21,6 +23,8 @@ type Reader struct {
 
 // A Content is a container for a [Header] and a byte slice.
 // It is used by the SDK's [Serializer] interface implementations.
+//
+// NOTE: Experimental
 type Content struct {
 	// Header that should include information on how to deserialize this content.
 	// Headers constructed by the framework always have lower case keys.
@@ -37,12 +41,16 @@ type Content struct {
 // called.
 //
 // ⚠️ When a LazyValue is passed to a server handler, it must not be used after the returning from the handler method.
+//
+// NOTE: Experimental
 type LazyValue struct {
 	serializer Serializer
 	Reader     *Reader
 }
 
 // Create a new [LazyValue] from a given serializer and reader.
+//
+// NOTE: Experimental
 func NewLazyValue(serializer Serializer, reader *Reader) *LazyValue {
 	return &LazyValue{
 		serializer: serializer,
@@ -92,6 +100,8 @@ var anyType = reflect.TypeOf((*any)(nil)).Elem()
 
 // ErrSerializerIncompatible is a sentinel error emitted by [Serializer] implementations to signal that a serializer is
 // incompatible with a given value or [Content].
+//
+// NOTE: Experimental
 var ErrSerializerIncompatible = errors.New("incompatible serializer")
 
 // CompositeSerializer is a [Serializer] that composes multiple serializers together.


### PR DESCRIPTION
Mark Handler, Serializer and other related concepts as experimental. These APIs may be removed with the expectation that a transport layer implement them rather than the SDK.

See also: https://github.com/nexus-rpc/sdk-python/pull/46